### PR TITLE
[Feat] Scan 기능 Domain/Data 레이어 구현

### DIFF
--- a/RoomLog/RoomLog.xcodeproj/project.pbxproj
+++ b/RoomLog/RoomLog.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0BC1FE092F8BCDCF00B9AA18 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 0BC1FE082F8BCDCF00B9AA18 /* ZIPFoundation */; };
 		0BEFDD972F84FDF900CDE2A6 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 0BEFDD962F84FDF900CDE2A6 /* Moya */; };
 /* End PBXBuildFile section */
 
@@ -41,6 +42,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0BEFDD972F84FDF900CDE2A6 /* Moya in Frameworks */,
+				0BC1FE092F8BCDCF00B9AA18 /* ZIPFoundation in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -84,6 +86,7 @@
 			name = RoomLog;
 			packageProductDependencies = (
 				0BEFDD962F84FDF900CDE2A6 /* Moya */,
+				0BC1FE082F8BCDCF00B9AA18 /* ZIPFoundation */,
 			);
 			productName = RoomLog;
 			productReference = 0B1EC4402F7BB970001FE02F /* RoomLog.app */;
@@ -115,6 +118,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				0BEFDD952F84FDF900CDE2A6 /* XCRemoteSwiftPackageReference "Moya" */,
+				0BC1FE072F8BCDCF00B9AA18 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 0B1EC4412F7BB970001FE02F /* Products */;
@@ -366,6 +370,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		0BC1FE072F8BCDCF00B9AA18 /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/weichsel/ZIPFoundation";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.20;
+			};
+		};
 		0BEFDD952F84FDF900CDE2A6 /* XCRemoteSwiftPackageReference "Moya" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Moya/Moya";
@@ -377,6 +389,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		0BC1FE082F8BCDCF00B9AA18 /* ZIPFoundation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0BC1FE072F8BCDCF00B9AA18 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
+			productName = ZIPFoundation;
+		};
 		0BEFDD962F84FDF900CDE2A6 /* Moya */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0BEFDD952F84FDF900CDE2A6 /* XCRemoteSwiftPackageReference "Moya" */;

--- a/RoomLog/RoomLog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RoomLog/RoomLog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8f916f5d4326b71e39effcaaa3b5d19d894467a03c60c9c5033a4bfc3cfd2d9c",
+  "originHash" : "cf0cc3fd2b142998bba2fbb79a0b702e307b83e7b4527cb14e7c642e16163db0",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -35,6 +35,15 @@
       "state" : {
         "revision" : "132aea4f236ccadc51590b38af0357a331d51fa2",
         "version" : "6.10.2"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation",
+      "state" : {
+        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version" : "0.9.20"
       }
     }
   ],

--- a/RoomLog/RoomLog/Features/Scan/Data/DTO/ScanResultResponseDTO.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/DTO/ScanResultResponseDTO.swift
@@ -1,0 +1,16 @@
+//
+//  ScanResultResponseDTO.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/12/26.
+//
+
+import Foundation
+
+struct ScanResultResponseDTO: Codable {
+    let scanId: Int
+
+    func toDomain() -> ScanResult {
+        ScanResult(scanId: scanId)
+    }
+}

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/ConfidenceEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/ConfidenceEncoder.swift
@@ -28,19 +28,24 @@ final class ConfidenceEncoder {
     }
 
     func encodeFrame(frame: CVPixelBuffer, frameNumber: Int) {
-        assert(
-            (previousFrame + 1) == frameNumber,
-            "ConfidenceEncoder: 프레임 누락. \(previousFrame + 1) != \(frameNumber)"
-        )
+        guard (previousFrame + 1) == frameNumber else {
+            status = .encodingError
+            return
+        }
+        guard CVPixelBufferGetPixelFormatType(frame) == kCVPixelFormatType_OneComponent8 else {
+            status = .encodingError
+            return
+        }
         previousFrame = frameNumber
-
-        assert(CVPixelBufferGetPixelFormatType(frame) == kCVPixelFormatType_OneComponent8)
 
         let filename = String(format: "%06d.png", frameNumber)
         let framePath = baseDirectory.appendingPathComponent(filename)
         let image = CIImage(cvPixelBuffer: frame)
 
-        guard let colorSpace = CGColorSpace(name: CGColorSpace.extendedGray) else { return }
+        guard let colorSpace = CGColorSpace(name: CGColorSpace.extendedGray) else {
+            status = .encodingError
+            return
+        }
         do {
             try ciContext.writePNGRepresentation(of: image, to: framePath, format: .L8, colorSpace: colorSpace)
         } catch {

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/ConfidenceEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/ConfidenceEncoder.swift
@@ -1,0 +1,51 @@
+//
+//  ConfidenceEncoder.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/12/26.
+//
+
+import Foundation
+import CoreImage
+
+final class ConfidenceEncoder {
+    enum Status { case allGood, encodingError }
+
+    private let baseDirectory: URL
+    private let ciContext: CIContext
+    private var previousFrame: Int = -1
+    var status: Status = .allGood
+
+    init(outDirectory: URL) {
+        self.baseDirectory = outDirectory
+        self.ciContext = CIContext()
+        do {
+            try FileManager.default.createDirectory(at: outDirectory, withIntermediateDirectories: true)
+        } catch {
+            print("ConfidenceEncoder: 디렉토리 생성 실패. \(error.localizedDescription)")
+            status = .encodingError
+        }
+    }
+
+    func encodeFrame(frame: CVPixelBuffer, frameNumber: Int) {
+        assert(
+            (previousFrame + 1) == frameNumber,
+            "ConfidenceEncoder: 프레임 누락. \(previousFrame + 1) != \(frameNumber)"
+        )
+        previousFrame = frameNumber
+
+        assert(CVPixelBufferGetPixelFormatType(frame) == kCVPixelFormatType_OneComponent8)
+
+        let filename = String(format: "%06d.png", frameNumber)
+        let framePath = baseDirectory.appendingPathComponent(filename)
+        let image = CIImage(cvPixelBuffer: frame)
+
+        guard let colorSpace = CGColorSpace(name: CGColorSpace.extendedGray) else { return }
+        do {
+            try ciContext.writePNGRepresentation(of: image, to: framePath, format: .L8, colorSpace: colorSpace)
+        } catch {
+            print("ConfidenceEncoder: PNG 저장 실패 (frame \(frameNumber)). \(error.localizedDescription)")
+            status = .encodingError
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
@@ -1,0 +1,177 @@
+//
+//  DatasetEncoder.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/12/26.
+//
+
+import Foundation
+import ARKit
+import CryptoKit
+import CoreMotion
+
+final class DatasetEncoder {
+    enum Status {
+        case allGood
+        case videoEncodingError
+        case directoryCreationError
+    }
+
+    private let rgbEncoder: VideoEncoder
+    private let depthEncoder: DepthEncoder
+    private let confidenceEncoder: ConfidenceEncoder
+    private let odometryEncoder: OdometryEncoder
+    private let imuEncoder: IMUEncoder
+    private let datasetDirectory: URL
+    private var dispatchGroup = DispatchGroup()
+    private let queue: DispatchQueue
+    private let frameInterval: Int
+    private var currentFrame: Int = -1
+    private var savedFrames: Int = 0
+    private var lastFrame: ARFrame?
+    private var latestAccelerometerData: (timestamp: Double, data: simd_double3)?
+    private var latestGyroscopeData: (timestamp: Double, data: simd_double3)?
+
+    // 녹화 완료 후 외부에서 접근하는 프로퍼티
+    let id: UUID
+    let datasetDirectoryURL: URL
+    let rgbFilePath: URL
+    let depthFilePath: URL
+    let cameraMatrixPath: URL
+    let odometryPath: URL
+    let imuPath: URL
+    var status: Status = .allGood
+
+    init(arConfiguration: ARWorldTrackingConfiguration, fpsDivider: Int = 1) {
+        self.frameInterval = fpsDivider
+        self.queue = DispatchQueue(label: "com.roomlog.encoderQueue")
+
+        let width = arConfiguration.videoFormat.imageResolution.width
+        let height = arConfiguration.videoFormat.imageResolution.height
+
+        var theId = UUID()
+        let directory = DatasetEncoder.createDirectory(id: &theId)
+        self.id = theId
+        self.datasetDirectory = directory
+        self.datasetDirectoryURL = directory
+
+        self.rgbFilePath = directory.appendingPathComponent("rgb.mp4")
+        self.rgbEncoder = VideoEncoder(file: rgbFilePath, width: width, height: height)
+
+        self.depthFilePath = directory.appendingPathComponent("depth", isDirectory: true)
+        self.depthEncoder = DepthEncoder(outDirectory: depthFilePath)
+
+        let confidencePath = directory.appendingPathComponent("confidence", isDirectory: true)
+        self.confidenceEncoder = ConfidenceEncoder(outDirectory: confidencePath)
+
+        self.cameraMatrixPath = directory.appendingPathComponent("camera_matrix.csv")
+        self.odometryPath = directory.appendingPathComponent("odometry.csv")
+        self.odometryEncoder = OdometryEncoder(url: odometryPath)
+
+        self.imuPath = directory.appendingPathComponent("imu.csv")
+        self.imuEncoder = IMUEncoder(url: imuPath)
+    }
+
+    func add(frame: ARFrame) {
+        currentFrame += 1
+        guard currentFrame % frameInterval == 0 else { return }
+
+        let frameNumber = savedFrames
+        let totalFrames = currentFrame
+        savedFrames += 1
+
+        dispatchGroup.enter()
+        queue.async { [weak self] in
+            guard let self else {
+                self?.dispatchGroup.leave()
+                return
+            }
+            if let sceneDepth = frame.sceneDepth {
+                self.depthEncoder.encodeFrame(frame: sceneDepth.depthMap, frameNumber: frameNumber)
+                if let confidence = sceneDepth.confidenceMap {
+                    self.confidenceEncoder.encodeFrame(frame: confidence, frameNumber: frameNumber)
+                }
+            }
+            self.rgbEncoder.add(
+                frame: VideoEncoderInput(buffer: frame.capturedImage, time: frame.timestamp),
+                currentFrame: totalFrames
+            )
+            self.odometryEncoder.add(frame: frame, currentFrame: frameNumber)
+            self.lastFrame = frame
+            self.dispatchGroup.leave()
+        }
+    }
+
+    func addRawAccelerometer(data: CMAccelerometerData) {
+        let acceleration = simd_double3(data.acceleration.x, data.acceleration.y, data.acceleration.z)
+        latestAccelerometerData = (timestamp: data.timestamp, data: acceleration)
+        tryWritingIMUData()
+    }
+
+    func addRawGyroscope(data: CMGyroData) {
+        let rotationRate = simd_double3(data.rotationRate.x, data.rotationRate.y, data.rotationRate.z)
+        latestGyroscopeData = (timestamp: data.timestamp, data: rotationRate)
+        tryWritingIMUData()
+    }
+
+    func wrapUp() {
+        dispatchGroup.wait()
+        rgbEncoder.finishEncoding()
+        imuEncoder.done()
+        odometryEncoder.done()
+        writeIntrinsics()
+
+        if case .error = rgbEncoder.status { status = .videoEncodingError }
+        if case .frameEncodingError = depthEncoder.status { status = .videoEncodingError }
+        if case .encodingError = confidenceEncoder.status { status = .videoEncodingError }
+    }
+
+    // MARK: - Private
+
+    private func tryWritingIMUData() {
+        guard let accelerometer = latestAccelerometerData,
+              let gyroscope = latestGyroscopeData else { return }
+
+        let timestamp = max(accelerometer.timestamp, gyroscope.timestamp)
+        imuEncoder.add(timestamp: timestamp, linear: accelerometer.data, angular: gyroscope.data)
+
+        latestAccelerometerData = nil
+        latestGyroscopeData = nil
+    }
+
+    private func writeIntrinsics() {
+        guard let cameraMatrix = lastFrame?.camera.intrinsics else { return }
+        let rows = cameraMatrix.transpose.columns
+        let csv = [rows.0, rows.1, rows.2].map { "\($0.x), \($0.y), \($0.z)" }.joined(separator: "\n")
+        do {
+            try csv.write(to: cameraMatrixPath, atomically: true, encoding: .utf8)
+        } catch {
+            print("DatasetEncoder: could not write camera matrix. \(error.localizedDescription)")
+        }
+    }
+
+    private static func createDirectory(id: inout UUID) -> URL {
+        let directoryName = hashUUID(id: id)
+        let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let directory = documentsURL.appendingPathComponent(directoryName, isDirectory: true)
+
+        if FileManager.default.fileExists(atPath: directory.path) {
+            id = UUID()
+            return createDirectory(id: &id)
+        }
+
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        } catch {
+            print("DatasetEncoder: could not create directory. \(error.localizedDescription)")
+        }
+        return directory
+    }
+
+    private static func hashUUID(id: UUID) -> String {
+        var hasher = SHA256()
+        hasher.update(data: id.uuidString.data(using: .ascii)!)
+        let digest = hasher.finalize()
+        return digest.prefix(5).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
@@ -24,6 +24,7 @@ final class DatasetEncoder {
     private let imuEncoder: IMUEncoder
     private let datasetDirectory: URL
     private var lastTask: Task<Void, Never>?
+    private var isFinalizing = false
     private let frameInterval: Int
     private let imuLock = NSLock()
     private var currentFrame: Int = -1
@@ -80,6 +81,7 @@ final class DatasetEncoder {
     }
 
     func add(frame: ARFrame) {
+        guard !isFinalizing else { return }
         currentFrame += 1
         guard currentFrame % frameInterval == 0 else { return }
 
@@ -106,6 +108,7 @@ final class DatasetEncoder {
     }
 
     func addRawAccelerometer(data: CMAccelerometerData) {
+        guard !isFinalizing else { return }
         imuLock.lock()
         defer { imuLock.unlock() }
         let acceleration = simd_double3(data.acceleration.x, data.acceleration.y, data.acceleration.z)
@@ -114,6 +117,7 @@ final class DatasetEncoder {
     }
 
     func addRawGyroscope(data: CMGyroData) {
+        guard !isFinalizing else { return }
         imuLock.lock()
         defer { imuLock.unlock() }
         let rotationRate = simd_double3(data.rotationRate.x, data.rotationRate.y, data.rotationRate.z)
@@ -122,11 +126,20 @@ final class DatasetEncoder {
     }
 
     func wrapUp() async {
+        isFinalizing = true
+
         await lastTask?.value
         lastTask = nil
 
         await rgbEncoder.finishEncoding()
-        try? imuEncoder.done()
+
+        do {
+            try imuEncoder.done()
+        } catch {
+            print("DatasetEncoder: IMU 파일 닫기 실패. \(error.localizedDescription)")
+            status = .videoEncodingError
+        }
+
         odometryEncoder.done()
         writeIntrinsics()
 

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
@@ -23,7 +23,7 @@ final class DatasetEncoder {
     private let odometryEncoder: OdometryEncoder
     private let imuEncoder: IMUEncoder
     private let datasetDirectory: URL
-    private var frameTasks: [Task<Void, Never>] = []
+    private var lastTask: Task<Void, Never>?
     private let frameInterval: Int
     private let imuLock = NSLock()
     private var currentFrame: Int = -1
@@ -87,7 +87,9 @@ final class DatasetEncoder {
         let totalFrames = currentFrame
         savedFrames += 1
 
-        let task = Task(priority: .utility) { [weak self] in
+        let previous = lastTask
+        lastTask = Task(priority: .utility) { [weak self] in
+            await previous?.value
             guard let self else { return }
             if let sceneDepth = frame.sceneDepth {
                 depthEncoder.encodeFrame(frame: sceneDepth.depthMap, frameNumber: frameNumber)
@@ -96,13 +98,11 @@ final class DatasetEncoder {
                 }
             }
             await rgbEncoder.add(
-                frame: VideoEncoderInput(buffer: frame.capturedImage, time: frame.timestamp),
-                currentFrame: totalFrames
+                frame: VideoEncoderInput(buffer: frame.capturedImage, time: frame.timestamp)
             )
             odometryEncoder.add(frame: frame, currentFrame: frameNumber)
             lastFrame = frame
         }
-        frameTasks.append(task)
     }
 
     func addRawAccelerometer(data: CMAccelerometerData) {
@@ -122,8 +122,8 @@ final class DatasetEncoder {
     }
 
     func wrapUp() async {
-        for task in frameTasks { await task.value }
-        frameTasks.removeAll()
+        await lastTask?.value
+        lastTask = nil
 
         await rgbEncoder.finishEncoding()
         try? imuEncoder.done()

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
@@ -23,8 +23,7 @@ final class DatasetEncoder {
     private let odometryEncoder: OdometryEncoder
     private let imuEncoder: IMUEncoder
     private let datasetDirectory: URL
-    private var dispatchGroup = DispatchGroup()
-    private let queue: DispatchQueue
+    private var frameTasks: [Task<Void, Never>] = []
     private let frameInterval: Int
     private let imuLock = NSLock()
     private var currentFrame: Int = -1
@@ -45,7 +44,6 @@ final class DatasetEncoder {
 
     init(arConfiguration: ARWorldTrackingConfiguration, fpsDivider: Int = 1) throws {
         self.frameInterval = max(1, fpsDivider)
-        self.queue = DispatchQueue(label: "com.roomlog.encoderQueue")
 
         let width = arConfiguration.videoFormat.imageResolution.width
         let height = arConfiguration.videoFormat.imageResolution.height
@@ -75,7 +73,7 @@ final class DatasetEncoder {
 
         self.cameraMatrixPath = directory.appendingPathComponent("camera_matrix.csv")
         self.odometryPath = directory.appendingPathComponent("odometry.csv")
-        self.odometryEncoder = OdometryEncoder(url: odometryPath)
+        self.odometryEncoder = try OdometryEncoder(url: odometryPath)
 
         self.imuPath = directory.appendingPathComponent("imu.csv")
         self.imuEncoder = try IMUEncoder(url: imuPath)
@@ -89,26 +87,22 @@ final class DatasetEncoder {
         let totalFrames = currentFrame
         savedFrames += 1
 
-        dispatchGroup.enter()
-        queue.async { [weak self] in
-            guard let self else {
-                self?.dispatchGroup.leave()
-                return
-            }
+        let task = Task(priority: .utility) { [weak self] in
+            guard let self else { return }
             if let sceneDepth = frame.sceneDepth {
-                self.depthEncoder.encodeFrame(frame: sceneDepth.depthMap, frameNumber: frameNumber)
+                depthEncoder.encodeFrame(frame: sceneDepth.depthMap, frameNumber: frameNumber)
                 if let confidence = sceneDepth.confidenceMap {
-                    self.confidenceEncoder.encodeFrame(frame: confidence, frameNumber: frameNumber)
+                    confidenceEncoder.encodeFrame(frame: confidence, frameNumber: frameNumber)
                 }
             }
-            self.rgbEncoder.add(
+            await rgbEncoder.add(
                 frame: VideoEncoderInput(buffer: frame.capturedImage, time: frame.timestamp),
                 currentFrame: totalFrames
             )
-            self.odometryEncoder.add(frame: frame, currentFrame: frameNumber)
-            self.lastFrame = frame
-            self.dispatchGroup.leave()
+            odometryEncoder.add(frame: frame, currentFrame: frameNumber)
+            lastFrame = frame
         }
+        frameTasks.append(task)
     }
 
     func addRawAccelerometer(data: CMAccelerometerData) {
@@ -128,9 +122,11 @@ final class DatasetEncoder {
     }
 
     func wrapUp() async {
-        dispatchGroup.wait()
+        for task in frameTasks { await task.value }
+        frameTasks.removeAll()
+
         await rgbEncoder.finishEncoding()
-        imuEncoder.done()
+        try? imuEncoder.done()
         odometryEncoder.done()
         writeIntrinsics()
 
@@ -179,7 +175,7 @@ final class DatasetEncoder {
 
     private static func hashUUID(id: UUID) -> String {
         var hasher = SHA256()
-        hasher.update(data: id.uuidString.data(using: .ascii)!)
+        hasher.update(data: Data(id.uuidString.utf8))
         let digest = hasher.finalize()
         return digest.prefix(5).map { String(format: "%02x", $0) }.joined()
     }

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
@@ -26,6 +26,7 @@ final class DatasetEncoder {
     private var dispatchGroup = DispatchGroup()
     private let queue: DispatchQueue
     private let frameInterval: Int
+    private let imuLock = NSLock()
     private var currentFrame: Int = -1
     private var savedFrames: Int = 0
     private var lastFrame: ARFrame?
@@ -42,15 +43,23 @@ final class DatasetEncoder {
     let imuPath: URL
     var status: Status = .allGood
 
-    init(arConfiguration: ARWorldTrackingConfiguration, fpsDivider: Int = 1) {
-        self.frameInterval = fpsDivider
+    init(arConfiguration: ARWorldTrackingConfiguration, fpsDivider: Int = 1) throws {
+        self.frameInterval = max(1, fpsDivider)
         self.queue = DispatchQueue(label: "com.roomlog.encoderQueue")
 
         let width = arConfiguration.videoFormat.imageResolution.width
         let height = arConfiguration.videoFormat.imageResolution.height
 
         var theId = UUID()
-        let directory = DatasetEncoder.createDirectory(id: &theId)
+        let directory: URL
+        do {
+            directory = try DatasetEncoder.createDirectory(id: &theId)
+        } catch {
+            self.status = .directoryCreationError
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(theId.uuidString, isDirectory: true)
+            try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            directory = tempDir
+        }
         self.id = theId
         self.datasetDirectory = directory
         self.datasetDirectoryURL = directory
@@ -69,7 +78,7 @@ final class DatasetEncoder {
         self.odometryEncoder = OdometryEncoder(url: odometryPath)
 
         self.imuPath = directory.appendingPathComponent("imu.csv")
-        self.imuEncoder = IMUEncoder(url: imuPath)
+        self.imuEncoder = try IMUEncoder(url: imuPath)
     }
 
     func add(frame: ARFrame) {
@@ -103,20 +112,24 @@ final class DatasetEncoder {
     }
 
     func addRawAccelerometer(data: CMAccelerometerData) {
+        imuLock.lock()
+        defer { imuLock.unlock() }
         let acceleration = simd_double3(data.acceleration.x, data.acceleration.y, data.acceleration.z)
         latestAccelerometerData = (timestamp: data.timestamp, data: acceleration)
         tryWritingIMUData()
     }
 
     func addRawGyroscope(data: CMGyroData) {
+        imuLock.lock()
+        defer { imuLock.unlock() }
         let rotationRate = simd_double3(data.rotationRate.x, data.rotationRate.y, data.rotationRate.z)
         latestGyroscopeData = (timestamp: data.timestamp, data: rotationRate)
         tryWritingIMUData()
     }
 
-    func wrapUp() {
+    func wrapUp() async {
         dispatchGroup.wait()
-        rgbEncoder.finishEncoding()
+        await rgbEncoder.finishEncoding()
         imuEncoder.done()
         odometryEncoder.done()
         writeIntrinsics()
@@ -150,21 +163,17 @@ final class DatasetEncoder {
         }
     }
 
-    private static func createDirectory(id: inout UUID) -> URL {
+    private static func createDirectory(id: inout UUID) throws -> URL {
         let directoryName = hashUUID(id: id)
         let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         let directory = documentsURL.appendingPathComponent(directoryName, isDirectory: true)
 
         if FileManager.default.fileExists(atPath: directory.path) {
             id = UUID()
-            return createDirectory(id: &id)
+            return try createDirectory(id: &id)
         }
 
-        do {
-            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        } catch {
-            print("DatasetEncoder: could not create directory. \(error.localizedDescription)")
-        }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         return directory
     }
 

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
@@ -169,6 +169,7 @@ final class DatasetEncoder {
             try csv.write(to: cameraMatrixPath, atomically: true, encoding: .utf8)
         } catch {
             print("DatasetEncoder: could not write camera matrix. \(error.localizedDescription)")
+            status = .videoEncodingError
         }
     }
 

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
@@ -86,7 +86,6 @@ final class DatasetEncoder {
         guard currentFrame % frameInterval == 0 else { return }
 
         let frameNumber = savedFrames
-        let totalFrames = currentFrame
         savedFrames += 1
 
         let previous = lastTask

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/DepthEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/DepthEncoder.swift
@@ -26,7 +26,10 @@ final class DepthEncoder {
     }
 
     func encodeFrame(frame: CVPixelBuffer, frameNumber: Int) {
-        assert(CVPixelBufferGetPixelFormatType(frame) == kCVPixelFormatType_DepthFloat32)
+        guard CVPixelBufferGetPixelFormatType(frame) == kCVPixelFormatType_DepthFloat32 else {
+            status = .frameEncodingError
+            return
+        }
 
         let filename = String(format: "%06d.png", frameNumber)
         let framePath = baseDirectory.appendingPathComponent(filename)
@@ -49,6 +52,10 @@ final class DepthEncoder {
         var uint16Pixels = [UInt16](repeating: 0, count: width * height)
         for i in 0..<(width * height) {
             let mm = floatPtr[i] * 1000.0
+            guard mm.isFinite, mm >= 0 else {
+                uint16Pixels[i] = 0
+                continue
+            }
             uint16Pixels[i] = UInt16(clamping: Int(mm.rounded())).bigEndian
         }
 

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/DepthEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/DepthEncoder.swift
@@ -1,0 +1,83 @@
+//
+//  DepthEncoder.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/12/26.
+//
+
+import Foundation
+import ARKit
+import ImageIO
+
+final class DepthEncoder {
+    enum Status { case allGood, frameEncodingError }
+
+    private let baseDirectory: URL
+    var status: Status = .allGood
+
+    init(outDirectory: URL) {
+        self.baseDirectory = outDirectory
+        do {
+            try FileManager.default.createDirectory(at: outDirectory, withIntermediateDirectories: true)
+        } catch {
+            print("DepthEncoder: 디렉토리 생성 실패. \(error.localizedDescription)")
+            status = .frameEncodingError
+        }
+    }
+
+    func encodeFrame(frame: CVPixelBuffer, frameNumber: Int) {
+        assert(CVPixelBufferGetPixelFormatType(frame) == kCVPixelFormatType_DepthFloat32)
+
+        let filename = String(format: "%06d.png", frameNumber)
+        let framePath = baseDirectory.appendingPathComponent(filename)
+
+        let width = CVPixelBufferGetWidth(frame)
+        let height = CVPixelBufferGetHeight(frame)
+
+        CVPixelBufferLockBaseAddress(frame, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(frame, .readOnly) }
+
+        guard let baseAddress = CVPixelBufferGetBaseAddress(frame) else {
+            print("DepthEncoder: base address 접근 실패 (frame \(frameNumber))")
+            status = .frameEncodingError
+            return
+        }
+
+        let floatPtr = baseAddress.assumingMemoryBound(to: Float32.self)
+
+        // Float32 meters → UInt16 millimeters, big-endian (PNG 표준)
+        var uint16Pixels = [UInt16](repeating: 0, count: width * height)
+        for i in 0..<(width * height) {
+            let mm = floatPtr[i] * 1000.0
+            uint16Pixels[i] = UInt16(clamping: Int(mm.rounded())).bigEndian
+        }
+
+        let success = uint16Pixels.withUnsafeMutableBytes { rawPtr -> Bool in
+            guard
+                let context = CGContext(
+                    data: rawPtr.baseAddress,
+                    width: width,
+                    height: height,
+                    bitsPerComponent: 16,
+                    bytesPerRow: width * 2,
+                    space: CGColorSpaceCreateDeviceGray(),
+                    bitmapInfo: CGBitmapInfo.byteOrder16Big.rawValue
+                ),
+                let cgImage = context.makeImage(),
+                let dest = CGImageDestinationCreateWithURL(
+                    framePath as CFURL,
+                    "public.png" as CFString,
+                    1, nil
+                )
+            else { return false }
+
+            CGImageDestinationAddImage(dest, cgImage, nil)
+            return CGImageDestinationFinalize(dest)
+        }
+
+        if !success {
+            print("DepthEncoder: PNG 저장 실패 (frame \(frameNumber))")
+            status = .frameEncodingError
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/IMUEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/IMUEncoder.swift
@@ -11,15 +11,11 @@ final class IMUEncoder {
     private let path: URL
     private let fileHandle: FileHandle
 
-    init(url: URL) {
+    init(url: URL) throws {
         self.path = url
-        do {
-            try "".write(to: url, atomically: true, encoding: .utf8)
-            self.fileHandle = try FileHandle(forWritingTo: url)
-            fileHandle.write("timestamp, a_x, a_y, a_z, alpha_x, alpha_y, alpha_z\n".data(using: .utf8)!)
-        } catch {
-            preconditionFailure("IMUEncoder: IMU 파일 열기 실패. \(error.localizedDescription)")
-        }
+        try "".write(to: url, atomically: true, encoding: .utf8)
+        self.fileHandle = try FileHandle(forWritingTo: url)
+        fileHandle.write("timestamp, a_x, a_y, a_z, alpha_x, alpha_y, alpha_z\n".data(using: .utf8)!)
     }
 
     func add(timestamp: Double, linear: simd_double3, angular: simd_double3) {

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/IMUEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/IMUEncoder.swift
@@ -1,0 +1,37 @@
+//
+//  IMUEncoder.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/12/26.
+//
+
+import Foundation
+
+final class IMUEncoder {
+    private let path: URL
+    private let fileHandle: FileHandle
+
+    init(url: URL) {
+        self.path = url
+        do {
+            try "".write(to: url, atomically: true, encoding: .utf8)
+            self.fileHandle = try FileHandle(forWritingTo: url)
+            fileHandle.write("timestamp, a_x, a_y, a_z, alpha_x, alpha_y, alpha_z\n".data(using: .utf8)!)
+        } catch {
+            preconditionFailure("IMUEncoder: IMU 파일 열기 실패. \(error.localizedDescription)")
+        }
+    }
+
+    func add(timestamp: Double, linear: simd_double3, angular: simd_double3) {
+        let line = "\(timestamp), \(linear.x), \(linear.y), \(linear.z), \(angular.x), \(angular.y), \(angular.z)\n"
+        fileHandle.write(line.data(using: .utf8)!)
+    }
+
+    func done() {
+        do {
+            try fileHandle.close()
+        } catch {
+            print("IMUEncoder: 파일 닫기 실패. \(error.localizedDescription)")
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/IMUEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/IMUEncoder.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import simd
 
 final class IMUEncoder {
     private let path: URL
@@ -15,19 +16,15 @@ final class IMUEncoder {
         self.path = url
         try "".write(to: url, atomically: true, encoding: .utf8)
         self.fileHandle = try FileHandle(forWritingTo: url)
-        fileHandle.write("timestamp, a_x, a_y, a_z, alpha_x, alpha_y, alpha_z\n".data(using: .utf8)!)
+        try fileHandle.write(contentsOf: Data("timestamp, a_x, a_y, a_z, alpha_x, alpha_y, alpha_z\n".utf8))
     }
 
     func add(timestamp: Double, linear: simd_double3, angular: simd_double3) {
         let line = "\(timestamp), \(linear.x), \(linear.y), \(linear.z), \(angular.x), \(angular.y), \(angular.z)\n"
-        fileHandle.write(line.data(using: .utf8)!)
+        try? fileHandle.write(contentsOf: Data(line.utf8))
     }
 
-    func done() {
-        do {
-            try fileHandle.close()
-        } catch {
-            print("IMUEncoder: 파일 닫기 실패. \(error.localizedDescription)")
-        }
+    func done() throws {
+        try fileHandle.close()
     }
 }

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/OdometryEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/OdometryEncoder.swift
@@ -1,0 +1,45 @@
+//
+//  OdometryEncoder.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/12/26.
+//
+
+import Foundation
+import ARKit
+import Accelerate
+
+final class OdometryEncoder {
+    private let path: URL
+    private let fileHandle: FileHandle
+    private let q_AC = simd_quatf(ix: 1.0, iy: 0.0, iz: 0.0, r: 0.0)
+
+    init(url: URL) {
+        self.path = url
+        do {
+            try "".write(to: url, atomically: true, encoding: .utf8)
+            self.fileHandle = try FileHandle(forWritingTo: url)
+            fileHandle.write("timestamp, frame, x, y, z, qx, qy, qz, qw\n".data(using: .utf8)!)
+        } catch {
+            preconditionFailure("OdometryEncoder: odometry 파일 열기 실패. \(error.localizedDescription)")
+        }
+    }
+
+    func add(frame: ARFrame, currentFrame: Int) {
+        let transform = frame.camera.transform
+        let t = transform[3]
+        let xyz = vector_float3(t.x, t.y, t.z)
+        let q = (simd_quatf(transform) * q_AC).vector
+        let frameNumber = String(format: "%06d", currentFrame)
+        let line = "\(frame.timestamp), \(frameNumber), \(xyz.x), \(xyz.y), \(xyz.z), \(q.x), \(q.y), \(q.z), \(q.w)\n"
+        fileHandle.write(line.data(using: .utf8)!)
+    }
+
+    func done() {
+        do {
+            try fileHandle.close()
+        } catch {
+            print("OdometryEncoder: 파일 닫기 실패. \(error.localizedDescription)")
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/OdometryEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/OdometryEncoder.swift
@@ -14,15 +14,11 @@ final class OdometryEncoder {
     private let fileHandle: FileHandle
     private let q_AC = simd_quatf(ix: 1.0, iy: 0.0, iz: 0.0, r: 0.0)
 
-    init(url: URL) {
+    init(url: URL) throws {
         self.path = url
-        do {
-            try "".write(to: url, atomically: true, encoding: .utf8)
-            self.fileHandle = try FileHandle(forWritingTo: url)
-            fileHandle.write("timestamp, frame, x, y, z, qx, qy, qz, qw\n".data(using: .utf8)!)
-        } catch {
-            preconditionFailure("OdometryEncoder: odometry 파일 열기 실패. \(error.localizedDescription)")
-        }
+        try "".write(to: url, atomically: true, encoding: .utf8)
+        self.fileHandle = try FileHandle(forWritingTo: url)
+        try fileHandle.write(contentsOf: Data("timestamp, frame, x, y, z, qx, qy, qz, qw\n".utf8))
     }
 
     func add(frame: ARFrame, currentFrame: Int) {
@@ -32,7 +28,7 @@ final class OdometryEncoder {
         let q = (simd_quatf(transform) * q_AC).vector
         let frameNumber = String(format: "%06d", currentFrame)
         let line = "\(frame.timestamp), \(frameNumber), \(xyz.x), \(xyz.y), \(xyz.z), \(q.x), \(q.y), \(q.z), \(q.w)\n"
-        fileHandle.write(line.data(using: .utf8)!)
+        try? fileHandle.write(contentsOf: Data(line.utf8))
     }
 
     func done() {

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
@@ -71,7 +71,10 @@ final class VideoEncoder {
                 sourcePixelBufferAttributes: nil
             )
 
-            guard writer.canAdd(input) else { return }
+            guard writer.canAdd(input) else {
+                status = .error
+                return
+            }
             writer.add(input)
             videoWriterInput = input
             videoAdapter = adapter
@@ -80,6 +83,7 @@ final class VideoEncoder {
             writer.startSession(atSourceTime: .zero)
         } catch {
             print("VideoEncoder: AVAssetWriter 생성 실패. \(error.localizedDescription)")
+            status = .error
         }
     }
 
@@ -92,15 +96,16 @@ final class VideoEncoder {
     }
 
     private func doneRecording() async {
-        guard videoWriter?.status != .failed else {
+        guard let writer = videoWriter else { return }
+        guard writer.status != .failed else {
             print("VideoEncoder: 인코딩 중 오류 발생.")
             status = .error
             return
         }
         videoWriterInput?.markAsFinished()
         await withCheckedContinuation { continuation in
-            videoWriter?.finishWriting { [weak self] in
-                if self?.videoWriter?.status == .failed { self?.status = .error }
+            writer.finishWriting { [weak self] in
+                if writer.status == .failed { self?.status = .error }
                 self?.videoWriter = nil
                 self?.videoWriterInput = nil
                 self?.videoAdapter = nil

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
@@ -35,13 +35,19 @@ final class VideoEncoder {
         initializeFile()
     }
 
-    func finishEncoding() {
-        doneRecording()
+    func finishEncoding() async {
+        await doneRecording()
     }
 
     func add(frame: VideoEncoderInput, currentFrame: Int) {
         previousFrame = currentFrame
+        var spinCount = 0
         while !(videoWriterInput?.isReadyForMoreMediaData ?? false) {
+            if videoWriter?.status == .failed || spinCount > 500 {
+                status = .error
+                return
+            }
+            spinCount += 1
             Thread.sleep(until: Date() + 0.01)
         }
         encode(frame: frame, frameNumber: currentFrame)
@@ -82,20 +88,25 @@ final class VideoEncoder {
         let time = CMTime(value: Int64(frameNumber), timescale: timeScale)
         if videoAdapter?.append(frame.buffer, withPresentationTime: time) == false {
             print("VideoEncoder: pixel buffer append 실패.")
+            status = .error
         }
     }
 
-    private func doneRecording() {
+    private func doneRecording() async {
         guard videoWriter?.status != .failed else {
             print("VideoEncoder: 인코딩 중 오류 발생.")
             status = .error
             return
         }
         videoWriterInput?.markAsFinished()
-        videoWriter?.finishWriting { [weak self] in
-            self?.videoWriter = nil
-            self?.videoWriterInput = nil
-            self?.videoAdapter = nil
+        await withCheckedContinuation { continuation in
+            videoWriter?.finishWriting { [weak self] in
+                if self?.videoWriter?.status == .failed { self?.status = .error }
+                self?.videoWriter = nil
+                self?.videoWriterInput = nil
+                self?.videoAdapter = nil
+                continuation.resume()
+            }
         }
     }
 }

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
@@ -39,7 +39,7 @@ final class VideoEncoder {
         await doneRecording()
     }
 
-    func add(frame: VideoEncoderInput, currentFrame: Int) {
+    func add(frame: VideoEncoderInput, currentFrame: Int) async {
         previousFrame = currentFrame
         var spinCount = 0
         while !(videoWriterInput?.isReadyForMoreMediaData ?? false) {
@@ -48,7 +48,7 @@ final class VideoEncoder {
                 return
             }
             spinCount += 1
-            Thread.sleep(until: Date() + 0.01)
+            try? await Task.sleep(nanoseconds: 10_000_000)
         }
         encode(frame: frame, frameNumber: currentFrame)
     }
@@ -57,7 +57,7 @@ final class VideoEncoder {
 
     private func initializeFile() {
         do {
-            videoWriter = try AVAssetWriter(outputURL: filePath, fileType: .mp4)
+            let writer = try AVAssetWriter(outputURL: filePath, fileType: .mp4)
             let settings: [String: Any] = [
                 AVVideoCodecKey: AVVideoCodecType.hevc,
                 AVVideoWidthKey: width,
@@ -68,17 +68,18 @@ final class VideoEncoder {
             input.mediaTimeScale = timeScale
             input.performsMultiPassEncodingIfSupported = false
 
-            videoAdapter = AVAssetWriterInputPixelBufferAdaptor(
+            let adapter = AVAssetWriterInputPixelBufferAdaptor(
                 assetWriterInput: input,
                 sourcePixelBufferAttributes: nil
             )
 
-            if videoWriter!.canAdd(input) {
-                videoWriter!.add(input)
-                videoWriterInput = input
-                videoWriter!.startWriting()
-                videoWriter!.startSession(atSourceTime: .zero)
-            }
+            guard writer.canAdd(input) else { return }
+            writer.add(input)
+            videoWriterInput = input
+            videoAdapter = adapter
+            videoWriter = writer
+            writer.startWriting()
+            writer.startSession(atSourceTime: .zero)
         } catch {
             print("VideoEncoder: AVAssetWriter 생성 실패. \(error.localizedDescription)")
         }

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import AVFoundation
+@preconcurrency import AVFoundation
 import ARKit
 
 struct VideoEncoderInput {
@@ -14,7 +14,7 @@ struct VideoEncoderInput {
     let time: TimeInterval
 }
 
-final class VideoEncoder {
+final class VideoEncoder: @unchecked Sendable {
     enum EncodingStatus { case allGood, error }
 
     private var videoWriter: AVAssetWriter?
@@ -105,7 +105,7 @@ final class VideoEncoder {
         videoWriterInput?.markAsFinished()
         await withCheckedContinuation { continuation in
             writer.finishWriting { [weak self] in
-                if writer.status == .failed { self?.status = .error }
+                if self?.videoWriter?.status == .failed { self?.status = .error }
                 self?.videoWriter = nil
                 self?.videoWriterInput = nil
                 self?.videoAdapter = nil

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
@@ -1,0 +1,101 @@
+//
+//  VideoEncoder.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/12/26.
+//
+
+import Foundation
+import AVFoundation
+import ARKit
+
+struct VideoEncoderInput {
+    let buffer: CVPixelBuffer
+    let time: TimeInterval
+}
+
+final class VideoEncoder {
+    enum EncodingStatus { case allGood, error }
+
+    private var videoWriter: AVAssetWriter?
+    private var videoWriterInput: AVAssetWriterInput?
+    private var videoAdapter: AVAssetWriterInputPixelBufferAdaptor?
+    private let timeScale = CMTimeScale(60)
+    private var previousFrame: Int = -1
+
+    let width: CGFloat
+    let height: CGFloat
+    let filePath: URL
+    var status: EncodingStatus = .allGood
+
+    init(file: URL, width: CGFloat, height: CGFloat) {
+        self.filePath = file
+        self.width = width
+        self.height = height
+        initializeFile()
+    }
+
+    func finishEncoding() {
+        doneRecording()
+    }
+
+    func add(frame: VideoEncoderInput, currentFrame: Int) {
+        previousFrame = currentFrame
+        while !(videoWriterInput?.isReadyForMoreMediaData ?? false) {
+            Thread.sleep(until: Date() + 0.01)
+        }
+        encode(frame: frame, frameNumber: currentFrame)
+    }
+
+    // MARK: - Private
+
+    private func initializeFile() {
+        do {
+            videoWriter = try AVAssetWriter(outputURL: filePath, fileType: .mp4)
+            let settings: [String: Any] = [
+                AVVideoCodecKey: AVVideoCodecType.hevc,
+                AVVideoWidthKey: width,
+                AVVideoHeightKey: height
+            ]
+            let input = AVAssetWriterInput(mediaType: .video, outputSettings: settings)
+            input.expectsMediaDataInRealTime = true
+            input.mediaTimeScale = timeScale
+            input.performsMultiPassEncodingIfSupported = false
+
+            videoAdapter = AVAssetWriterInputPixelBufferAdaptor(
+                assetWriterInput: input,
+                sourcePixelBufferAttributes: nil
+            )
+
+            if videoWriter!.canAdd(input) {
+                videoWriter!.add(input)
+                videoWriterInput = input
+                videoWriter!.startWriting()
+                videoWriter!.startSession(atSourceTime: .zero)
+            }
+        } catch {
+            print("VideoEncoder: AVAssetWriter 생성 실패. \(error.localizedDescription)")
+        }
+    }
+
+    private func encode(frame: VideoEncoderInput, frameNumber: Int) {
+        let time = CMTime(value: Int64(frameNumber), timescale: timeScale)
+        if videoAdapter?.append(frame.buffer, withPresentationTime: time) == false {
+            print("VideoEncoder: pixel buffer append 실패.")
+        }
+    }
+
+    private func doneRecording() {
+        guard videoWriter?.status != .failed else {
+            print("VideoEncoder: 인코딩 중 오류 발생.")
+            status = .error
+            return
+        }
+        videoWriterInput?.markAsFinished()
+        videoWriter?.finishWriting { [weak self] in
+            self?.videoWriter = nil
+            self?.videoWriterInput = nil
+            self?.videoAdapter = nil
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
@@ -20,8 +20,7 @@ final class VideoEncoder {
     private var videoWriter: AVAssetWriter?
     private var videoWriterInput: AVAssetWriterInput?
     private var videoAdapter: AVAssetWriterInputPixelBufferAdaptor?
-    private let timeScale = CMTimeScale(60)
-    private var previousFrame: Int = -1
+    private let timeScale = CMTimeScale(600)
 
     let width: CGFloat
     let height: CGFloat
@@ -39,8 +38,7 @@ final class VideoEncoder {
         await doneRecording()
     }
 
-    func add(frame: VideoEncoderInput, currentFrame: Int) async {
-        previousFrame = currentFrame
+    func add(frame: VideoEncoderInput) async {
         var spinCount = 0
         while !(videoWriterInput?.isReadyForMoreMediaData ?? false) {
             if videoWriter?.status == .failed || spinCount > 500 {
@@ -50,7 +48,7 @@ final class VideoEncoder {
             spinCount += 1
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
-        encode(frame: frame, frameNumber: currentFrame)
+        encode(frame: frame)
     }
 
     // MARK: - Private
@@ -85,8 +83,8 @@ final class VideoEncoder {
         }
     }
 
-    private func encode(frame: VideoEncoderInput, frameNumber: Int) {
-        let time = CMTime(value: Int64(frameNumber), timescale: timeScale)
+    private func encode(frame: VideoEncoderInput) {
+        let time = CMTime(seconds: frame.time, preferredTimescale: timeScale)
         if videoAdapter?.append(frame.buffer, withPresentationTime: time) == false {
             print("VideoEncoder: pixel buffer append 실패.")
             status = .error

--- a/RoomLog/RoomLog/Features/Scan/Data/Repositories/ScanRepository.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Repositories/ScanRepository.swift
@@ -22,7 +22,11 @@ final class ScanRepository: ScanRepositoryProtocol {
     // MARK: - Function
     func uploadScan(roomId: Int, zipFileURL: URL) async throws -> ScanResult {
         let response = try await adapter.request(ScanTarget.uploadScan(roomId: roomId, zipFileURL: zipFileURL))
-        let dto = try decoder.decode(APIResponse<ScanResultResponseDTO>.self, from: response.data)
-        return try dto.unwrap().toDomain()
+        do {
+            let dto = try decoder.decode(APIResponse<ScanResultResponseDTO>.self, from: response.data)
+            return try dto.unwrap().toDomain()
+        } catch let error as DecodingError {
+            throw RepositoryError.decodingError(detail: String(describing: error))
+        }
     }
 }

--- a/RoomLog/RoomLog/Features/Scan/Data/Repositories/ScanRepository.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Repositories/ScanRepository.swift
@@ -1,0 +1,28 @@
+//
+//  ScanRepository.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/12/26.
+//
+
+import Foundation
+import Moya
+
+final class ScanRepository: ScanRepositoryProtocol {
+    // MARK: - Property
+    private let adapter: MoyaNetworkAdapter
+    private let decoder: JSONDecoder
+
+    // MARK: - Init
+    init(adapter: MoyaNetworkAdapter, decoder: JSONDecoder = JSONDecoder()) {
+        self.adapter = adapter
+        self.decoder = decoder
+    }
+
+    // MARK: - Function
+    func uploadScan(roomId: Int, zipFileURL: URL) async throws -> ScanResult {
+        let response = try await adapter.request(ScanTarget.uploadScan(roomId: roomId, zipFileURL: zipFileURL))
+        let dto = try decoder.decode(APIResponse<ScanResultResponseDTO>.self, from: response.data)
+        return try dto.unwrap().toDomain()
+    }
+}

--- a/RoomLog/RoomLog/Features/Scan/Data/Repositories/ScanRepository.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Repositories/ScanRepository.swift
@@ -22,11 +22,7 @@ final class ScanRepository: ScanRepositoryProtocol {
     // MARK: - Function
     func uploadScan(roomId: Int, zipFileURL: URL) async throws -> ScanResult {
         let response = try await adapter.request(ScanTarget.uploadScan(roomId: roomId, zipFileURL: zipFileURL))
-        do {
-            let dto = try decoder.decode(APIResponse<ScanResultResponseDTO>.self, from: response.data)
-            return try dto.unwrap().toDomain()
-        } catch let error as DecodingError {
-            throw RepositoryError.decodingError(detail: String(describing: error))
-        }
+        let dto = try decoder.decode(APIResponse<ScanResultResponseDTO>.self, from: response.data)
+        return try dto.unwrap().toDomain()
     }
 }

--- a/RoomLog/RoomLog/Features/Scan/Data/Target/ScanTarget.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Target/ScanTarget.swift
@@ -1,0 +1,40 @@
+//
+//  ScanTarget.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/12/26.
+//
+
+import Foundation
+import Moya
+internal import Alamofire
+
+enum ScanTarget {
+    case uploadScan(roomId: Int, zipFileURL: URL)
+}
+
+extension ScanTarget: BaseTargetType {
+    var path: String {
+        switch self {
+        case .uploadScan(let roomId, _):
+            return "/rooms/\(roomId)/scans"
+        }
+    }
+
+    var method: Moya.Method {
+        .post
+    }
+
+    var task: Moya.Task {
+        switch self {
+        case .uploadScan(_, let zipFileURL):
+            let formData = MultipartFormData(
+                provider: .file(zipFileURL),
+                name: "file",
+                fileName: "scan.zip",
+                mimeType: "application/zip"
+            )
+            return .uploadMultipart([formData])
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Scan/Domain/Interfaces/ScanRepositoryProtocol.swift
+++ b/RoomLog/RoomLog/Features/Scan/Domain/Interfaces/ScanRepositoryProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  ScanRepositoryProtocol.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/12/26.
+//
+
+import Foundation
+
+protocol ScanRepositoryProtocol {
+    func uploadScan(roomId: Int, zipFileURL: URL) async throws -> ScanResult
+}

--- a/RoomLog/RoomLog/Features/Scan/Domain/Models/ScanResult.swift
+++ b/RoomLog/RoomLog/Features/Scan/Domain/Models/ScanResult.swift
@@ -1,0 +1,12 @@
+//
+//  ScanResult.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/12/26.
+//
+
+import Foundation
+
+struct ScanResult {
+    let scanId: Int
+}

--- a/RoomLog/RoomLog/Features/Scan/Domain/UseCases/Implementations/UploadScanUseCase.swift
+++ b/RoomLog/RoomLog/Features/Scan/Domain/UseCases/Implementations/UploadScanUseCase.swift
@@ -1,0 +1,37 @@
+//
+//  UploadScanUseCase.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/12/26.
+//
+
+import Foundation
+import ZIPFoundation
+
+final class UploadScanUseCase: UploadScanUseCaseProtocol {
+    // MARK: - Property
+    private let repository: ScanRepositoryProtocol
+
+    // MARK: - Init
+    init(repository: ScanRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+    func execute(datasetDirectory: URL, roomId: Int) async throws -> ScanResult {
+        let zipURL = datasetDirectory
+            .deletingLastPathComponent()
+            .appendingPathComponent(datasetDirectory.lastPathComponent + ".zip")
+
+        // 1. 데이터셋 폴더 → zip 압축
+        try FileManager.default.zipItem(at: datasetDirectory, to: zipURL)
+
+        defer {
+            // 3. 업로드 성공/실패 무관하게 zip 파일 정리
+            try? FileManager.default.removeItem(at: zipURL)
+        }
+
+        // 2. 서버 업로드
+        return try await repository.uploadScan(roomId: roomId, zipFileURL: zipURL)
+    }
+}

--- a/RoomLog/RoomLog/Features/Scan/Domain/UseCases/Implementations/UploadScanUseCase.swift
+++ b/RoomLog/RoomLog/Features/Scan/Domain/UseCases/Implementations/UploadScanUseCase.swift
@@ -23,8 +23,10 @@ final class UploadScanUseCase: UploadScanUseCaseProtocol {
             .deletingLastPathComponent()
             .appendingPathComponent(datasetDirectory.lastPathComponent + ".zip")
 
-        // 1. 데이터셋 폴더 → zip 압축
-        try FileManager.default.zipItem(at: datasetDirectory, to: zipURL)
+        // 1. 데이터셋 폴더 → zip 압축 (백그라운드에서 실행)
+        try await Task.detached(priority: .utility) {
+            try FileManager.default.zipItem(at: datasetDirectory, to: zipURL)
+        }.value
 
         defer {
             // 3. 업로드 성공/실패 무관하게 zip 파일 정리

--- a/RoomLog/RoomLog/Features/Scan/Domain/UseCases/UploadScanUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/Scan/Domain/UseCases/UploadScanUseCaseProtocol.swift
@@ -1,0 +1,16 @@
+//
+//  UploadScanUseCaseProtocol.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/12/26.
+//
+
+import Foundation
+
+protocol UploadScanUseCaseProtocol {
+    /// 스캔 데이터셋 디렉토리를 zip으로 압축 후 서버에 업로드합니다.
+    /// - Parameters:
+    ///   - datasetDirectory: DatasetEncoder가 저장한 데이터셋 폴더 URL
+    ///   - roomId: 업로드할 방 ID
+    func execute(datasetDirectory: URL, roomId: Int) async throws -> ScanResult
+}


### PR DESCRIPTION
## ✨ PR 유형
- [x] 새로운 기능 추가

<br>

## 🛠️ 작업 내용
- 스캔 데이터 인코더 추가 (DatasetEncoder, VideoEncoder, DepthEncoder, ConfidenceEncoder, OdometryEncoder, IMUEncoder)
  - DepthEncoder: C++/lodepng 대신 iOS 네이티브 CGContext + CGImageDestination 사용
  - StrayScanner와 동일한 데이터 포맷 유지 (rgb.mp4, depth/, confidence/, CSV 파일)
- ScanResult 도메인 모델 및 ScanResultResponseDTO 추가
- ScanRepositoryProtocol, ScanRepository 추가
- ScanTarget multipart 업로드 엔드포인트 추가
- UploadScanUseCaseProtocol, UploadScanUseCase 추가 (ZIPFoundation으로 데이터셋 폴더 zip 압축 후 서버 업로드)

<br>

## 🔍 관련 이슈
- closed #14

<br>

## 📸 스크린샷 - UI작업인 경우만 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * AR 룸 스캔을 세션별로 기록하여 프레임별 비디오, 깊이, 신뢰도 이미지, IMU 및 오도메트리 데이터를 저장
  * 저장된 세션을 ZIP으로 생성해 서버에 업로드하고 업로드 결과(스캔 ID)를 반환하는 흐름 추가
* **Chores**
  * ZIP 압축 처리를 위한 패키지 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->