### PR TITLE
[Feat] Defect의 Data/Domain layer 및 DI 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ Moya + 커스텀 `NetworkClient(actor)` 조합으로 구성됩니다.
 | merge | 브랜치 병합 |
 
 ### Example
-```
+```text
 feat: 하자 점검 화면 구현
 fix: 방 목록 조회 오류 수정
 refactor: DefectViewModel 구조 변경

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ RoomLog/RoomLog/
 
 ## Architecture
 
-Clean Architecture 패턴을 따르며, 기능(Feature) 기반 폴더 구조를 사용합니다.
+Clean Architecture + MVVM 패턴을 따르며, 기능(Feature) 기반 폴더 구조를 사용합니다.
 각 Feature는 `Data/`, `Domain/`, `Presentation/` 레이어로 구분됩니다.
 
 ### Dependency Injection
@@ -97,6 +97,48 @@ Moya + 커스텀 `NetworkClient(actor)` 조합으로 구성됩니다.
 
 - 상태 및 라우터 클래스에는 `ObservableObject` 대신 **`@Observable`** 사용.
 - 새로운 기능은 `Features/[기능명]/Presentation/`에 위치시키며, 필요에 따라 `Domain/`, `Data/` 레이어를 추가합니다.
+
+### Commit Convention
+
+| Tag | Description |
+|-----|-------------|
+| feat | 새로운 기능 추가 |
+| fix | 버그 수정 |
+| design | UI 수정 |
+| typo | 오타 수정 |
+| mod | 폴더 구조 이동 및 파일 이름 수정 |
+| add | 파일 추가 |
+| del | 파일 삭제 |
+| refactor | 코드 리팩토링 |
+| init | 프로젝트 세팅 |
+| chore | 배포, 빌드 등 기타 작업 |
+| merge | 브랜치 병합 |
+
+### Example
+```
+feat: 하자 점검 화면 구현
+fix: 방 목록 조회 오류 수정
+refactor: DefectViewModel 구조 변경
+```
+
+### Commit Granularity (커밋 단위 규칙)
+
+커밋은 반드시 최소 단위로 나눠서 작성한다. 여러 파일을 한 번에 커밋하지 않는다.
+
+- **파일 단위**: 역할이 다른 파일은 각각 별도 커밋
+- **폴더/레이어 단위**: 같은 레이어(Domain, Data, Core 등)의 유사한 파일들은 묶어서 커밋
+- **절대 금지**: 서로 다른 레이어(예: Domain + Data + Core)를 한 커밋에 포함하지 않는다
+
+**예시 (Defect 도메인 추가 시)**
+```
+add: Defect 도메인 모델 추가 (DefectRoomData, DefectReport, DefectReportDetail)
+add: DefectRepositoryProtocol 추가
+add: Defect UseCase 프로토콜 추가 (GetDefectRoomData, GetDefectReport, GetDefectReportDetail)
+add: Defect UseCase 구현체 추가
+add: DefectTarget, DefectRepository 추가
+feat: UseCaseProvider에 Defect 의존성 추가
+feat: DIContainer에 UseCaseProvider 등록 방식으로 개선
+```
 
 ### 새로운 화면 추가 절차
 

--- a/RoomLog/RoomLog/Core/DIContainer/DIContainer.swift
+++ b/RoomLog/RoomLog/Core/DIContainer/DIContainer.swift
@@ -54,9 +54,6 @@ final class DIContainer {
 extension DIContainer {
     static func configured() -> DIContainer {
         let container = DIContainer()
-        container.register(UseCaseProvider.self) { UseCaseProvider() }
-        
-        
         // MARK: - Token Store
         container.register(TokenStore.self) {
             KeychainTokenStore()
@@ -69,15 +66,19 @@ extension DIContainer {
                 tokenStore: container.resolve(TokenStore.self)
             )
         }
-        
+
         container.register(MoyaNetworkAdapter.self) {
             MoyaNetworkAdapter(
                 networkClient: container.resolve(NetworkClient.self),
                 baseURL: URL(string: Config.baseURL)!
             )
         }
-        
-        
+
+        // MARK: - UseCase Provider
+        container.register(UseCaseProvider.self) {
+            UseCaseProvider(adapter: container.resolve(MoyaNetworkAdapter.self))
+        }
+
         return container
     }
 }

--- a/RoomLog/RoomLog/Core/DIContainer/UsecaseProvider.swift
+++ b/RoomLog/RoomLog/Core/DIContainer/UsecaseProvider.swift
@@ -5,13 +5,33 @@
 //  Created by 김도연 on 3/31/26.
 //
 
-
 import Foundation
 
 protocol UsecaseProvider {
-    
+    func makeGetDefectRoomDataUseCase() -> GetDefectRoomDataUseCaseProtocol
+    func makeGetDefectReportUseCase() -> GetDefectReportUseCaseProtocol
+    func makeGetDefectReportDetailUseCase() -> GetDefectReportDetailUseCaseProtocol
 }
 
 class UseCaseProvider: UsecaseProvider {
-    
+    // MARK: - Repository (같은 인스턴스를 각 UseCase에 공유)
+    private let defectRepository: DefectRepositoryProtocol
+
+    // MARK: - Init
+    init(adapter: MoyaNetworkAdapter) {
+        self.defectRepository = DefectRepository(adapter: adapter)
+    }
+
+    // MARK: - Defect UseCases
+    func makeGetDefectRoomDataUseCase() -> GetDefectRoomDataUseCaseProtocol {
+        GetDefectRoomDataUseCase(repository: defectRepository)
+    }
+
+    func makeGetDefectReportUseCase() -> GetDefectReportUseCaseProtocol {
+        GetDefectReportUseCase(repository: defectRepository)
+    }
+
+    func makeGetDefectReportDetailUseCase() -> GetDefectReportDetailUseCaseProtocol {
+        GetDefectReportDetailUseCase(repository: defectRepository)
+    }
 }

--- a/RoomLog/RoomLog/Features/Defect/Data/DTO/DefectDTO.swift
+++ b/RoomLog/RoomLog/Features/Defect/Data/DTO/DefectDTO.swift
@@ -1,0 +1,19 @@
+//
+//  DefectDTO.swift
+//  
+//
+//  Created by 송민교 on 4/12/26.
+//
+import Foundation
+
+// MARK: - Response DTO
+struct DefectDataResponseDTO: Codable {
+    let mainDefect: DefectSummaryDTO
+    let defects: [DefectSummaryDTO]
+    let defectsCount: Int
+}
+ 
+// TODO: - 추후 수정
+struct DefectSummaryDTO: Codable {
+    
+}

--- a/RoomLog/RoomLog/Features/Defect/Data/Repositories/DefectRepository.swift
+++ b/RoomLog/RoomLog/Features/Defect/Data/Repositories/DefectRepository.swift
@@ -22,19 +22,19 @@ final class DefectRepository: DefectRepositoryProtocol {
     // MARK: - Function
     func getDefectRoomData() async throws -> DefectRoomData {
         // TODO: DTO 확정 후 실제 디코딩 구현
-        let _ = try await adapter.request(DefectTarget.getDefectRoomData)
-        fatalError("getDefectRoomData: DTO 미구현")
+        let response = try await adapter.request(DefectTarget.getDefectRoomData)
+        throw RepositoryError.decodingError(detail: "getDefectRoomData DTO 미구현. status=\(response.statusCode), bytes=\(response.data.count)")
     }
 
     func getDefectReport(roomId: Int) async throws -> DefectReport {
         // TODO: DTO 확정 후 실제 디코딩 구현
-        let _ = try await adapter.request(DefectTarget.getDefectReport(roomId: roomId))
-        fatalError("getDefectReport: DTO 미구현")
+        let response = try await adapter.request(DefectTarget.getDefectReport(roomId: roomId))
+        throw RepositoryError.decodingError(detail: "getDefectReport DTO 미구현. status=\(response.statusCode), bytes=\(response.data.count)")
     }
 
     func getDefectReportDetail(roomId: Int, reportId: Int) async throws -> DefectReportDetail {
         // TODO: DTO 확정 후 실제 디코딩 구현
-        let _ = try await adapter.request(DefectTarget.getDefectReportDetail(roomId: roomId, reportId: reportId))
-        fatalError("getDefectReportDetail: DTO 미구현")
+        let response = try await adapter.request(DefectTarget.getDefectReportDetail(roomId: roomId, reportId: reportId))
+        throw RepositoryError.decodingError(detail: "getDefectReportDetail DTO 미구현. status=\(response.statusCode), bytes=\(response.data.count)")
     }
 }

--- a/RoomLog/RoomLog/Features/Defect/Data/Repositories/DefectRepository.swift
+++ b/RoomLog/RoomLog/Features/Defect/Data/Repositories/DefectRepository.swift
@@ -1,0 +1,40 @@
+//
+//  DefectRepository.swift
+//
+//
+//  Created by 송민교 on 4/12/26.
+//
+
+import Foundation
+import Moya
+
+final class DefectRepository: DefectRepositoryProtocol {
+    // MARK: - Property
+    private let adapter: MoyaNetworkAdapter
+    private let decoder: JSONDecoder
+
+    // MARK: - Init
+    init(adapter: MoyaNetworkAdapter, decoder: JSONDecoder = JSONDecoder()) {
+        self.adapter = adapter
+        self.decoder = decoder
+    }
+
+    // MARK: - Function
+    func getDefectRoomData() async throws -> DefectRoomData {
+        // TODO: DTO 확정 후 실제 디코딩 구현
+        let _ = try await adapter.request(DefectTarget.getDefectRoomData)
+        fatalError("getDefectRoomData: DTO 미구현")
+    }
+
+    func getDefectReport(roomId: Int) async throws -> DefectReport {
+        // TODO: DTO 확정 후 실제 디코딩 구현
+        let _ = try await adapter.request(DefectTarget.getDefectReport(roomId: roomId))
+        fatalError("getDefectReport: DTO 미구현")
+    }
+
+    func getDefectReportDetail(roomId: Int, reportId: Int) async throws -> DefectReportDetail {
+        // TODO: DTO 확정 후 실제 디코딩 구현
+        let _ = try await adapter.request(DefectTarget.getDefectReportDetail(roomId: roomId, reportId: reportId))
+        fatalError("getDefectReportDetail: DTO 미구현")
+    }
+}

--- a/RoomLog/RoomLog/Features/Defect/Data/Target/DefectTarget.swift
+++ b/RoomLog/RoomLog/Features/Defect/Data/Target/DefectTarget.swift
@@ -1,0 +1,37 @@
+//
+//  DefectTarget.swift
+//
+//
+//  Created by 송민교 on 4/12/26.
+//
+
+import Foundation
+import Moya
+internal import Alamofire
+
+enum DefectTarget {
+    case getDefectRoomData
+    case getDefectReport(roomId: Int)
+    case getDefectReportDetail(roomId: Int, reportId: Int)
+}
+
+extension DefectTarget: BaseTargetType {
+    var path: String {
+        switch self {
+        case .getDefectRoomData:
+            return "/defects"
+        case .getDefectReport(let roomId):
+            return "/rooms/\(roomId)/defects"
+        case .getDefectReportDetail(let roomId, let reportId):
+            return "/rooms/\(roomId)/defects/\(reportId)"
+        }
+    }
+
+    var method: Moya.Method {
+        return .get
+    }
+
+    var task: Moya.Task {
+        return .requestPlain
+    }
+}

--- a/RoomLog/RoomLog/Features/Defect/Domain/Interfaces/DefectRepositoryProtocol.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/Interfaces/DefectRepositoryProtocol.swift
@@ -1,0 +1,18 @@
+//
+//  DefectRepositoryProtocol.swift
+//  
+//
+//  Created by 송민교 on 4/12/26.
+//
+import Foundation
+
+protocol DefectRepositoryProtocol {
+    /// 메인 하자 점검 방 조회
+    func getDefectRoomData() async throws -> DefectRoomData
+    
+    /// 선택한 방 하자 정보 조회
+    func getDefectReport(roomId: Int) async throws -> DefectReport
+    
+    /// 선택한 방 하자 정보 상세 조회
+    func getDefectReportDetail(roomId: Int, reportId: Int) async throws -> DefectReportDetail
+}

--- a/RoomLog/RoomLog/Features/Defect/Domain/Models/DefectReport.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/Models/DefectReport.swift
@@ -4,6 +4,7 @@
 //
 //  Created by 송민교 on 4/12/26.
 //
+import Foundation
 
 struct DefectReport {
     let room: DefectRoomData

--- a/RoomLog/RoomLog/Features/Defect/Domain/Models/DefectReport.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/Models/DefectReport.swift
@@ -1,0 +1,14 @@
+//
+//  DefectData.swift
+//  
+//
+//  Created by 송민교 on 4/12/26.
+//
+
+struct DefectReport {
+    let room: DefectRoomData
+    let defectCount: Int
+    let minRepairCost: Int
+    let repairArea: Float
+    let defects: [DefectReportDetail]
+}

--- a/RoomLog/RoomLog/Features/Defect/Domain/Models/DefectReportDetail.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/Models/DefectReportDetail.swift
@@ -1,0 +1,23 @@
+//
+//  DefectReportDetail.swift
+//  
+//
+//  Created by 송민교 on 4/12/26.
+//
+
+struct DefectReportDetail {
+    let id: String
+    let defectThumbnailURL: URL
+    let type: String
+    let severity: Severity
+    let description: String
+    let repairCost: Int
+    let defectArea: Double
+    let location: String
+    let discoveredDate: Date
+    let memo: String?
+}
+
+enum Severity {
+    case hight, medium, low
+}

--- a/RoomLog/RoomLog/Features/Defect/Domain/Models/DefectReportDetail.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/Models/DefectReportDetail.swift
@@ -4,6 +4,7 @@
 //
 //  Created by 송민교 on 4/12/26.
 //
+import Foundation
 
 struct DefectReportDetail {
     let id: String
@@ -19,5 +20,5 @@ struct DefectReportDetail {
 }
 
 enum Severity {
-    case hight, medium, low
+    case high, medium, low
 }

--- a/RoomLog/RoomLog/Features/Defect/Domain/Models/DefectRoomData.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/Models/DefectRoomData.swift
@@ -4,6 +4,7 @@
 //
 //  Created by 송민교 on 4/12/26.
 //
+import Foundation
 
 struct DefectRoomData {
     let id: Int

--- a/RoomLog/RoomLog/Features/Defect/Domain/Models/DefectRoomData.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/Models/DefectRoomData.swift
@@ -1,0 +1,13 @@
+//
+//  DefectDetail.swift
+//  
+//
+//  Created by 송민교 on 4/12/26.
+//
+
+struct DefectRoomData {
+    let id: Int
+    let title: String
+    let date: Date
+    let thumbnailURL: String?
+}

--- a/RoomLog/RoomLog/Features/Defect/Domain/UseCases/GetDefectReportDetailUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/UseCases/GetDefectReportDetailUseCaseProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  GetDefectReportDetailUseCaseProtocol.swift
+//
+//
+//  Created by 송민교 on 4/12/26.
+//
+
+import Foundation
+
+/// 선택한 방의 하자 상세 정보 조회 UseCaseProtocol
+protocol GetDefectReportDetailUseCaseProtocol {
+    func execute(roomId: Int, reportId: Int) async throws -> DefectReportDetail
+}

--- a/RoomLog/RoomLog/Features/Defect/Domain/UseCases/GetDefectReportUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/UseCases/GetDefectReportUseCaseProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  GetDefectReportUseCaseProtocol.swift
+//
+//
+//  Created by 송민교 on 4/12/26.
+//
+
+import Foundation
+
+/// 선택한 방의 하자 보고서 조회 UseCaseProtocol
+protocol GetDefectReportUseCaseProtocol {
+    func execute(roomId: Int) async throws -> DefectReport
+}

--- a/RoomLog/RoomLog/Features/Defect/Domain/UseCases/GetDefectRoomDataUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/UseCases/GetDefectRoomDataUseCaseProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  GetDefectRoomDataUseCase.swift
+//  
+//
+//  Created by 송민교 on 4/12/26.
+//
+
+import Foundation
+
+/// 맨 처음 방 조회 UseCaseProtocol
+protocol GetDefectRoomDataUseCaseProtocol {
+    func execute() async throws -> DefectRoomData
+}

--- a/RoomLog/RoomLog/Features/Defect/Domain/UseCases/Implementations/GetDefectReportDetailUseCase.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/UseCases/Implementations/GetDefectReportDetailUseCase.swift
@@ -1,0 +1,23 @@
+//
+//  GetDefectReportDetailUseCase.swift
+//
+//
+//  Created by 송민교 on 4/12/26.
+//
+
+import Foundation
+
+final class GetDefectReportDetailUseCase: GetDefectReportDetailUseCaseProtocol {
+    // MARK: - Property
+    private let repository: DefectRepositoryProtocol
+
+    // MARK: - Init
+    init(repository: DefectRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+    func execute(roomId: Int, reportId: Int) async throws -> DefectReportDetail {
+        try await repository.getDefectReportDetail(roomId: roomId, reportId: reportId)
+    }
+}

--- a/RoomLog/RoomLog/Features/Defect/Domain/UseCases/Implementations/GetDefectReportUseCase.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/UseCases/Implementations/GetDefectReportUseCase.swift
@@ -1,0 +1,23 @@
+//
+//  GetDefectReportUseCase.swift
+//
+//
+//  Created by 송민교 on 4/12/26.
+//
+
+import Foundation
+
+final class GetDefectReportUseCase: GetDefectReportUseCaseProtocol {
+    // MARK: - Property
+    private let repository: DefectRepositoryProtocol
+
+    // MARK: - Init
+    init(repository: DefectRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+    func execute(roomId: Int) async throws -> DefectReport {
+        try await repository.getDefectReport(roomId: roomId)
+    }
+}

--- a/RoomLog/RoomLog/Features/Defect/Domain/UseCases/Implementations/GetDefectRoomDataUseCase.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/UseCases/Implementations/GetDefectRoomDataUseCase.swift
@@ -1,0 +1,23 @@
+//
+//  GetDefectRoomDataUseCase.swift
+//
+//
+//  Created by 송민교 on 4/12/26.
+//
+
+import Foundation
+
+final class GetDefectRoomDataUseCase: GetDefectRoomDataUseCaseProtocol {
+    // MARK: - Property
+    private let repository: DefectRepositoryProtocol
+
+    // MARK: - Init
+    init(repository: DefectRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Function
+    func execute() async throws -> DefectRoomData {
+        try await repository.getDefectRoomData()
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형
- [ ] feature

<br>

## 🛠️ 작업 내용
-  하자 점검(Defect) 기능의 Domain/Data 레이어 구현 및 DI 연결

**Data Layer**                                                                                    
- DefectTarget(Moya) 추가
- DefectRepository 스텁 구현 (DTO 확정 후 디코딩 구현 예정)

**Domain Layer**
- DefectRoomData, DefectReport, DefectReportDetail 도메인 모델 정의
- DefectRepositoryProtocol 및 UseCase 프로토콜 3개 정의
- UseCase 구현체 3개 작성 (GetDefectRoomData, GetDefectReport, GetDefectReportDetail)
- UseCaseProvider에 DefectRepository 싱글톤 관리
- DIContainer에 UseCaseProvider 등록 방식 개선

<br>

## 🔍 관련 이슈
- closed #17 

<br>

## 📸 스크린샷 - UI작업인 경우만 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 결함(Defect) 관련 도메인 모델, 리포트·세부 조회용 사용사례(Use Case) 및 데이터 접근 흐름 추가

* **문서화**
  * 아키텍처 설명을 Clean Architecture + MVVM으로 명시화
  * 커밋 컨벤션 및 커밋 분할(Granularity) 규칙 문서화

* **개선**
  * 의존성 주입 설정 및 제공자 등록 순서 최적화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->