### PR TITLE
[Fix] APIResponse 서버 응답 형식 맞춤 수정

### DIFF
--- a/RoomLog/RoomLog/Core/Error/RepositoryError.swift
+++ b/RoomLog/RoomLog/Core/Error/RepositoryError.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum RepositoryError: Error, LocalizedError, Sendable, Equatable {
     
-    case serverError(code: String?, message: String?)
+    case serverError(code: Int?, message: String?)
     
     case decodingError(detail: String?)
     
@@ -22,7 +22,7 @@ enum RepositoryError: Error, LocalizedError, Sendable, Equatable {
         }
     }
     
-    var code: String? {
+    var code: Int? {
         switch self {
         case .serverError(let code, _):
             return code
@@ -30,9 +30,9 @@ enum RepositoryError: Error, LocalizedError, Sendable, Equatable {
             return nil
         }
     }
-    
+
     var errorCode: String {
-        code ?? "unknown code"
+        code.map { String($0) } ?? "unknown code"
     }
     
     var userMessage: String {

--- a/RoomLog/RoomLog/Core/NetworkAdapter/Base/APIResponse.swift
+++ b/RoomLog/RoomLog/Core/NetworkAdapter/Base/APIResponse.swift
@@ -13,7 +13,7 @@ struct APIResponse<T: Codable>: Codable {
     /// 요청 성공 여부
     let isSuccess: Bool
     /// 응답 코드
-    let code: String?
+    let code: Int?
     /// 응답 메세지
     let message: String?
     /// 응답 결과
@@ -24,7 +24,7 @@ struct APIResponse<T: Codable>: Codable {
         case isSuccess = "success"
         case code
         case message
-        case result
+        case result = "data"
     }
 }
 

--- a/RoomLog/RoomLog/Core/NetworkAdapter/NetworkClient/DefaultAuthenticationPolicy.swift
+++ b/RoomLog/RoomLog/Core/NetworkAdapter/NetworkClient/DefaultAuthenticationPolicy.swift
@@ -17,10 +17,11 @@ struct DefaultAuthenticationPolicy: AuthenticationPolicy, Sendable {
 
     ///
     /// - Parameter request: 판단할 URLRequest
-    /// - Returns: 항상  `true`
-    ///   -> 모든 API 요청에 인증 적용
+    /// - Returns: 항상  `true` / API요청이 auth로 시작하는 경우 `false`
+    /// 
     nonisolated func requireAuthentication(_ request: URLRequest) -> Bool {
-        true
+        guard let path = request.url?.path else { return true }
+        return !path.hasPrefix("/auth/")
     }
     
     /// 401 Unautherized 응답을 인증 실패로 판단


### PR DESCRIPTION
## Summary
- APIResponse의 `result` CodingKey를 `"data"`로 변경 (서버 응답 키 매칭)
- `code` 타입을 `String?`에서 `Int?`로 변경 (서버가 정수 코드 반환)
- `RepositoryError.serverError` code 타입도 `Int?`로 통일
- `DefaultAuthenticationPolicy`에서 `/auth/` 경로 인증 제외 처리

## Test plan
- [ ] Xcode 빌드 성공 확인
- [ ] 기존 API 호출 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * 인증 경로 처리 개선으로 안정성 향상

* **개선 사항**
  * 내부 오류 처리 및 네트워크 응답 데이터 구조 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->