### PR TITLE
[Feat] Auth Data/Domain 레이어 구현

### DIFF
--- a/RoomLog/RoomLog/Features/Auth/Data/DTO/AuthDTO.swift
+++ b/RoomLog/RoomLog/Features/Auth/Data/DTO/AuthDTO.swift
@@ -1,0 +1,72 @@
+//
+//  AuthDTO.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+// MARK: - Request DTO
+
+struct LoginRequestDTO: Encodable {
+    let email: String
+    let password: String
+}
+
+struct SignUpRequestDTO: Encodable {
+    let email: String
+    let password: String
+    let nickname: String
+}
+
+// MARK: - Response DTO
+
+struct LoginResponseDTO: Codable {
+    let userId: Int
+    let email: String
+    let nickname: String
+    let accessToken: String
+    let refreshToken: String
+    let tokenType: String
+
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case email
+        case nickname
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
+        case tokenType = "token_type"
+    }
+
+    func toDomain() -> AuthUser {
+        AuthUser(
+            userId: userId,
+            email: email,
+            nickname: nickname
+        )
+    }
+}
+
+struct SignUpResponseDTO: Codable {
+    let userId: Int
+    let email: String
+    let nickname: String
+    let createdAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case email
+        case nickname
+        case createdAt = "created_at"
+    }
+
+    func toDomain() -> SignedUpUser {
+        SignedUpUser(
+            userId: userId,
+            email: email,
+            nickname: nickname,
+            createdAt: Date.fromServerDateTime(createdAt) ?? Date()
+        )
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Data/Repositories/AuthRepository.swift
+++ b/RoomLog/RoomLog/Features/Auth/Data/Repositories/AuthRepository.swift
@@ -1,0 +1,45 @@
+//
+//  AuthRepository.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+import Moya
+
+final class AuthRepository: AuthRepositoryProtocol {
+    // MARK: - Property
+    private let adapter: MoyaNetworkAdapter
+    private let tokenStore: TokenStore
+    private let decoder: JSONDecoder
+
+    // MARK: - Init
+    init(adapter: MoyaNetworkAdapter, tokenStore: TokenStore, decoder: JSONDecoder = JSONDecoder()) {
+        self.adapter = adapter
+        self.tokenStore = tokenStore
+        self.decoder = decoder
+    }
+
+    // MARK: - Function
+    func login(email: String, password: String) async throws -> AuthUser {
+        let request = LoginRequestDTO(email: email, password: password)
+        let response = try await adapter.request(AuthTarget.login(request: request))
+        let dto = try decoder.decode(APIResponse<LoginResponseDTO>.self, from: response.data)
+        let result = try dto.unwrap()
+
+        try await tokenStore.save(
+            accessToken: result.accessToken,
+            refreshToken: result.refreshToken
+        )
+
+        return result.toDomain()
+    }
+
+    func signUp(email: String, password: String, nickname: String) async throws -> SignedUpUser {
+        let request = SignUpRequestDTO(email: email, password: password, nickname: nickname)
+        let response = try await adapter.request(AuthTarget.signup(request: request))
+        let dto = try decoder.decode(APIResponse<SignUpResponseDTO>.self, from: response.data)
+        return try dto.unwrap().toDomain()
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Data/Target/AuthTarget.swift
+++ b/RoomLog/RoomLog/Features/Auth/Data/Target/AuthTarget.swift
@@ -1,0 +1,39 @@
+//
+//  AuthTarget.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+import Moya
+internal import Alamofire
+
+enum AuthTarget {
+    case login(request: LoginRequestDTO)
+    case signup(request: SignUpRequestDTO)
+}
+
+extension AuthTarget: BaseTargetType {
+    var path: String {
+        switch self {
+        case .login:
+            return "/auth/login"
+        case .signup:
+            return "/auth/signup"
+        }
+    }
+
+    var method: Moya.Method {
+        .post
+    }
+
+    var task: Moya.Task {
+        switch self {
+        case .login(let request):
+            return .requestJSONEncodable(request)
+        case .signup(let request):
+            return .requestJSONEncodable(request)
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
+++ b/RoomLog/RoomLog/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  AuthRepositoryProtocol.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+protocol AuthRepositoryProtocol {
+    func login(email: String, password: String) async throws -> AuthUser
+    func signUp(email: String, password: String, nickname: String) async throws -> SignedUpUser
+}

--- a/RoomLog/RoomLog/Features/Auth/Domain/Models/AuthUser.swift
+++ b/RoomLog/RoomLog/Features/Auth/Domain/Models/AuthUser.swift
@@ -1,0 +1,21 @@
+//
+//  AuthUser.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+struct AuthUser {
+    let userId: Int
+    let email: String
+    let nickname: String
+}
+
+struct SignedUpUser {
+    let userId: Int
+    let email: String
+    let nickname: String
+    let createdAt: Date
+}

--- a/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Implementations/LoginUseCase.swift
+++ b/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Implementations/LoginUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  LoginUseCase.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+final class LoginUseCase: LoginUseCaseProtocol {
+    private let repository: AuthRepositoryProtocol
+
+    init(repository: AuthRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(email: String, password: String) async throws -> AuthUser {
+        try await repository.login(email: email, password: password)
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Implementations/SignUpUseCase.swift
+++ b/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Implementations/SignUpUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  SignUpUseCase.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+final class SignUpUseCase: SignUpUseCaseProtocol {
+    private let repository: AuthRepositoryProtocol
+
+    init(repository: AuthRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(email: String, password: String, nickname: String) async throws -> SignedUpUser {
+        try await repository.signUp(email: email, password: password, nickname: nickname)
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Protocols/LoginUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Protocols/LoginUseCaseProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  LoginUseCaseProtocol.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+protocol LoginUseCaseProtocol {
+    func execute(email: String, password: String) async throws -> AuthUser
+}

--- a/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Protocols/SignUpUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Protocols/SignUpUseCaseProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  SignUpUseCaseProtocol.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+protocol SignUpUseCaseProtocol {
+    func execute(email: String, password: String, nickname: String) async throws -> SignedUpUser
+}


### PR DESCRIPTION
## Summary
- `AuthDTO`: 로그인/회원가입 요청·응답 DTO
- `AuthTarget`: Moya TargetType (`/auth/login`, `/auth/signup`)
- `AuthRepository`: 로그인 시 토큰 자동 저장 포함
- `AuthUser`, `SignedUpUser` 도메인 모델
- `LoginUseCase`, `SignUpUseCase` 및 프로토콜

## Test plan
- [ ] Xcode 빌드 성공 확인
- [ ] #28 머지 후 이 PR 머지

## Dependencies
- #28 (fix/api-response-format)