### PR TITLE
[Feat] Auth UI 및 앱 진입점 로그인 분기 구현

### DIFF
--- a/RoomLog/RoomLog.xcodeproj/project.pbxproj
+++ b/RoomLog/RoomLog.xcodeproj/project.pbxproj
@@ -153,6 +153,8 @@
 /* Begin XCBuildConfiguration section */
 		0B1EC4492F7BB971001FE02F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 0B1EC4422F7BB970001FE02F /* RoomLog */;
+			baseConfigurationReferenceRelativePath = Core/Config/Config.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -217,6 +219,8 @@
 		};
 		0B1EC44A2F7BB971001FE02F /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 0B1EC4422F7BB970001FE02F /* RoomLog */;
+			baseConfigurationReferenceRelativePath = Core/Config/Config.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -274,6 +278,8 @@
 		};
 		0B1EC44C2F7BB971001FE02F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 0B1EC4422F7BB970001FE02F /* RoomLog */;
+			baseConfigurationReferenceRelativePath = Core/Config/Config.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -312,6 +318,8 @@
 		};
 		0B1EC44D2F7BB971001FE02F /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 0B1EC4422F7BB970001FE02F /* RoomLog */;
+			baseConfigurationReferenceRelativePath = Core/Config/Config.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/RoomLog/RoomLog/App/ContentView.swift
+++ b/RoomLog/RoomLog/App/ContentView.swift
@@ -8,17 +8,30 @@
 import SwiftUI
 
 struct ContentView: View {
+    @Environment(\.di) var di: DIContainer
+    @State private var isLoggedIn: Bool?
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        Group {
+            switch isLoggedIn {
+            case .none:
+                ProgressView()
+            case .some(true):
+                RoomLogTab()
+            case .some(false):
+                LoginView {
+                    isLoggedIn = true
+                }
+            }
         }
-        .padding()
+        .task {
+            let networkClient = di.resolve(NetworkClient.self)
+            isLoggedIn = await networkClient.isLoggedIn()
+        }
     }
 }
 
 #Preview {
     ContentView()
+        .environment(\.di, DIContainer.configured())
 }

--- a/RoomLog/RoomLog/App/RoomLogApp.swift
+++ b/RoomLog/RoomLog/App/RoomLogApp.swift
@@ -13,7 +13,7 @@ struct RoomLogApp: App {
     
     var body: some Scene {
         WindowGroup {
-            RoomLogTab()
+            ContentView()
                 .environment(\.di, di)
         }
     }

--- a/RoomLog/RoomLog/Core/DIContainer/DIContainer.swift
+++ b/RoomLog/RoomLog/Core/DIContainer/DIContainer.swift
@@ -75,6 +75,13 @@ extension DIContainer {
         }
 
         // MARK: - UseCase Providers
+        container.register(AuthUseCaseProvider.self) {
+            AuthUseCaseProviderImpl(
+                adapter: container.resolve(MoyaNetworkAdapter.self),
+                tokenStore: container.resolve(TokenStore.self)
+            )
+        }
+
         container.register(HomeUseCaseProvider.self) {
             HomeUseCaseProviderImpl(adapter: container.resolve(MoyaNetworkAdapter.self))
         }

--- a/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum NavigationDestination: Hashable {
     enum Auth: Hashable {
-        case test
+        case signup
     }
     
     enum Home: Hashable {

--- a/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
@@ -32,8 +32,8 @@ private extension NavigationRoutingView {
     @ViewBuilder
     func authView(_ route: NavigationDestination.Auth) -> some View {
         switch route {
-        case .test:
-            Text("Auth Test View")
+        case .signup:
+            SignUpView()
         }
     }
     

--- a/RoomLog/RoomLog/Features/Auth/Presentation/Provider/AuthUseCaseProvider.swift
+++ b/RoomLog/RoomLog/Features/Auth/Presentation/Provider/AuthUseCaseProvider.swift
@@ -1,0 +1,32 @@
+//
+//  AuthUseCaseProvider.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+protocol AuthUseCaseProvider {
+    func makeLoginUseCase() -> LoginUseCaseProtocol
+    func makeSignUpUseCase() -> SignUpUseCaseProtocol
+}
+
+final class AuthUseCaseProviderImpl: AuthUseCaseProvider {
+    // MARK: - Repository
+    private let authRepository: AuthRepositoryProtocol
+
+    // MARK: - Init
+    init(adapter: MoyaNetworkAdapter, tokenStore: TokenStore) {
+        self.authRepository = AuthRepository(adapter: adapter, tokenStore: tokenStore)
+    }
+
+    // MARK: - Auth UseCases
+    func makeLoginUseCase() -> LoginUseCaseProtocol {
+        LoginUseCase(repository: authRepository)
+    }
+
+    func makeSignUpUseCase() -> SignUpUseCaseProtocol {
+        SignUpUseCase(repository: authRepository)
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Presentation/ViewModels/LoginViewModel.swift
+++ b/RoomLog/RoomLog/Features/Auth/Presentation/ViewModels/LoginViewModel.swift
@@ -1,0 +1,48 @@
+//
+//  LoginViewModel.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+@Observable
+final class LoginViewModel {
+    // MARK: - Input
+    var email: String = ""
+    var password: String = ""
+
+    // MARK: - State
+    var isLoading: Bool = false
+    var errorMessage: String?
+    var isLoggedIn: Bool = false
+
+    // MARK: - Dependencies
+    private let loginUseCase: LoginUseCaseProtocol
+
+    init(loginUseCase: LoginUseCaseProtocol) {
+        self.loginUseCase = loginUseCase
+    }
+
+    // MARK: - Actions
+    var isFormValid: Bool {
+        !email.isEmpty && !password.isEmpty
+    }
+
+    func login() async {
+        guard isFormValid else { return }
+
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            _ = try await loginUseCase.execute(email: email, password: password)
+            isLoggedIn = true
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
+++ b/RoomLog/RoomLog/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  SignUpViewModel.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+@Observable
+final class SignUpViewModel {
+    // MARK: - Input
+    var email: String = ""
+    var password: String = ""
+    var nickname: String = ""
+
+    // MARK: - State
+    var isLoading: Bool = false
+    var errorMessage: String?
+    var isSignUpCompleted: Bool = false
+
+    // MARK: - Dependencies
+    private let signUpUseCase: SignUpUseCaseProtocol
+
+    init(signUpUseCase: SignUpUseCaseProtocol) {
+        self.signUpUseCase = signUpUseCase
+    }
+
+    // MARK: - Actions
+    var isFormValid: Bool {
+        !email.isEmpty && !password.isEmpty && !nickname.isEmpty
+    }
+
+    func signUp() async {
+        guard isFormValid else { return }
+
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            _ = try await signUpUseCase.execute(
+                email: email,
+                password: password,
+                nickname: nickname
+            )
+            isSignUpCompleted = true
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Presentation/Views/LoginView.swift
+++ b/RoomLog/RoomLog/Features/Auth/Presentation/Views/LoginView.swift
@@ -1,0 +1,116 @@
+//
+//  LoginView.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import SwiftUI
+
+struct LoginView: View {
+    @Environment(\.di) var di: DIContainer
+    @State private var viewModel: LoginViewModel?
+    @State private var showSignUp = false
+
+    var onLoginSuccess: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                Spacer()
+
+                // MARK: - Logo
+                Image("Logo")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 120)
+                    .padding(.bottom, 48)
+
+                // MARK: - Input Fields
+                if let viewModel {
+                    VStack(spacing: 16) {
+                        TextField("이메일", text: Bindable(viewModel).email)
+                            .textContentType(.emailAddress)
+                            .keyboardType(.emailAddress)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .padding(16)
+                            .background(Color("neutral50"))
+                            .cornerRadius(12)
+                            .font(.medium, 16)
+
+                        SecureField("비밀번호", text: Bindable(viewModel).password)
+                            .textContentType(.password)
+                            .padding(16)
+                            .background(Color("neutral50"))
+                            .cornerRadius(12)
+                            .font(.medium, 16)
+                    }
+                    .padding(.horizontal, 24)
+
+                    // MARK: - Error Message
+                    if let errorMessage = viewModel.errorMessage {
+                        Text(errorMessage)
+                            .foregroundStyle(.red)
+                            .font(.regular, 14)
+                            .padding(.top, 12)
+                            .padding(.horizontal, 24)
+                    }
+
+                    // MARK: - Login Button
+                    Button {
+                        Task { await viewModel.login() }
+                    } label: {
+                        Group {
+                            if viewModel.isLoading {
+                                ProgressView()
+                                    .tint(.white)
+                            } else {
+                                Text("로그인")
+                                    .font(.semibold, 16)
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 52)
+                        .foregroundStyle(.white)
+                        .background(viewModel.isFormValid ? Color("deepNavy") : Color("neutral300"))
+                        .cornerRadius(12)
+                    }
+                    .disabled(!viewModel.isFormValid || viewModel.isLoading)
+                    .padding(.horizontal, 24)
+                    .padding(.top, 24)
+
+                    // MARK: - Sign Up Link
+                    Button {
+                        showSignUp = true
+                    } label: {
+                        HStack(spacing: 4) {
+                            Text("계정이 없으신가요?")
+                                .foregroundStyle(Color("neutral500"))
+                            Text("회원가입")
+                                .foregroundStyle(Color("deepNavy"))
+                        }
+                        .font(.medium, 14)
+                    }
+                    .padding(.top, 16)
+                }
+
+                Spacer()
+            }
+            .navigationDestination(isPresented: $showSignUp) {
+                SignUpView()
+            }
+            .onChange(of: viewModel?.isLoggedIn) { _, newValue in
+                if newValue == true {
+                    onLoginSuccess()
+                }
+            }
+        }
+        .onAppear {
+            if viewModel == nil {
+                let provider = di.resolve(AuthUseCaseProvider.self)
+                viewModel = LoginViewModel(loginUseCase: provider.makeLoginUseCase())
+            }
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Presentation/Views/SignUpView.swift
+++ b/RoomLog/RoomLog/Features/Auth/Presentation/Views/SignUpView.swift
@@ -85,17 +85,6 @@ struct SignUpView: View {
 
             Spacer()
         }
-        .navigationBarBackButtonHidden(true)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button {
-                    dismiss()
-                } label: {
-                    Image(systemName: "chevron.left")
-                        .foregroundStyle(Color("neutral900"))
-                }
-            }
-        }
         .onChange(of: viewModel?.isSignUpCompleted) { _, newValue in
             if newValue == true {
                 dismiss()

--- a/RoomLog/RoomLog/Features/Auth/Presentation/Views/SignUpView.swift
+++ b/RoomLog/RoomLog/Features/Auth/Presentation/Views/SignUpView.swift
@@ -1,0 +1,111 @@
+//
+//  SignUpView.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import SwiftUI
+
+struct SignUpView: View {
+    @Environment(\.di) var di: DIContainer
+    @Environment(\.dismiss) var dismiss
+    @State private var viewModel: SignUpViewModel?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            // MARK: - Title
+            Text("회원가입")
+                .font(.bold, 24)
+                .foregroundStyle(Color("neutral900"))
+                .padding(.bottom, 32)
+
+            // MARK: - Input Fields
+            if let viewModel {
+                VStack(spacing: 16) {
+                    TextField("이메일", text: Bindable(viewModel).email)
+                        .textContentType(.emailAddress)
+                        .keyboardType(.emailAddress)
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                        .padding(16)
+                        .background(Color("neutral50"))
+                        .cornerRadius(12)
+                        .font(.medium, 16)
+
+                    SecureField("비밀번호", text: Bindable(viewModel).password)
+                        .textContentType(.newPassword)
+                        .padding(16)
+                        .background(Color("neutral50"))
+                        .cornerRadius(12)
+                        .font(.medium, 16)
+
+                    TextField("닉네임", text: Bindable(viewModel).nickname)
+                        .padding(16)
+                        .background(Color("neutral50"))
+                        .cornerRadius(12)
+                        .font(.medium, 16)
+                }
+                .padding(.horizontal, 24)
+
+                // MARK: - Error Message
+                if let errorMessage = viewModel.errorMessage {
+                    Text(errorMessage)
+                        .foregroundStyle(.red)
+                        .font(.regular, 14)
+                        .padding(.top, 12)
+                        .padding(.horizontal, 24)
+                }
+
+                // MARK: - Sign Up Button
+                Button {
+                    Task { await viewModel.signUp() }
+                } label: {
+                    Group {
+                        if viewModel.isLoading {
+                            ProgressView()
+                                .tint(.white)
+                        } else {
+                            Text("회원가입")
+                                .font(.semibold, 16)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 52)
+                    .foregroundStyle(.white)
+                    .background(viewModel.isFormValid ? Color("deepNavy") : Color("neutral300"))
+                    .cornerRadius(12)
+                }
+                .disabled(!viewModel.isFormValid || viewModel.isLoading)
+                .padding(.horizontal, 24)
+                .padding(.top, 24)
+            }
+
+            Spacer()
+        }
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .foregroundStyle(Color("neutral900"))
+                }
+            }
+        }
+        .onChange(of: viewModel?.isSignUpCompleted) { _, newValue in
+            if newValue == true {
+                dismiss()
+            }
+        }
+        .onAppear {
+            if viewModel == nil {
+                let provider = di.resolve(AuthUseCaseProvider.self)
+                viewModel = SignUpViewModel(signUpUseCase: provider.makeSignUpUseCase())
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `AuthUseCaseProvider` 프로토콜 및 구현체
- `LoginViewModel`, `SignUpViewModel` (@Observable)
- `LoginView`: 이메일/비밀번호 입력 + 로그인 버튼 + 회원가입 링크
- `SignUpView`: 이메일/비밀번호/닉네임 입력 + 회원가입 버튼
- `ContentView`에서 토큰 존재 여부로 `LoginView`/`RoomLogTab` 분기
- `RoomLogApp` 루트를 `ContentView`로 변경
- `NavigationDestination.Auth`에 `.signup` 케이스 추가
- `DIContainer`에 `AuthUseCaseProvider` 등록

## Test plan
- [ ] Xcode 빌드 성공 확인
- [ ] 로그인 화면 → 회원가입 화면 전환 확인
- [ ] 로그인 성공 시 탭 화면 전환 확인
- [ ] #29 머지 후 이 PR 머지

## Dependencies
- #29 (feat/auth-data-domain)
- #28 (fix/api-response-format)