### PR TITLE
[Feat] Auth Data/Domain 레이어 구현

### DIFF
--- a/RoomLog/RoomLog.xcodeproj/project.pbxproj
+++ b/RoomLog/RoomLog.xcodeproj/project.pbxproj
@@ -153,6 +153,8 @@
 /* Begin XCBuildConfiguration section */
 		0B1EC4492F7BB971001FE02F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 0B1EC4422F7BB970001FE02F /* RoomLog */;
+			baseConfigurationReferenceRelativePath = Core/Config/Config.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -217,6 +219,8 @@
 		};
 		0B1EC44A2F7BB971001FE02F /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 0B1EC4422F7BB970001FE02F /* RoomLog */;
+			baseConfigurationReferenceRelativePath = Core/Config/Config.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -274,6 +278,8 @@
 		};
 		0B1EC44C2F7BB971001FE02F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 0B1EC4422F7BB970001FE02F /* RoomLog */;
+			baseConfigurationReferenceRelativePath = Core/Config/Config.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -312,6 +318,8 @@
 		};
 		0B1EC44D2F7BB971001FE02F /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 0B1EC4422F7BB970001FE02F /* RoomLog */;
+			baseConfigurationReferenceRelativePath = Core/Config/Config.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/RoomLog/RoomLog/App/ContentView.swift
+++ b/RoomLog/RoomLog/App/ContentView.swift
@@ -8,17 +8,30 @@
 import SwiftUI
 
 struct ContentView: View {
+    @Environment(\.di) var di: DIContainer
+    @State private var isLoggedIn: Bool?
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        Group {
+            switch isLoggedIn {
+            case .none:
+                ProgressView()
+            case .some(true):
+                RoomLogTab()
+            case .some(false):
+                LoginView {
+                    isLoggedIn = true
+                }
+            }
         }
-        .padding()
+        .task {
+            let networkClient = di.resolve(NetworkClient.self)
+            isLoggedIn = await networkClient.isLoggedIn()
+        }
     }
 }
 
 #Preview {
     ContentView()
+        .environment(\.di, DIContainer.configured())
 }

--- a/RoomLog/RoomLog/App/RoomLogApp.swift
+++ b/RoomLog/RoomLog/App/RoomLogApp.swift
@@ -13,7 +13,7 @@ struct RoomLogApp: App {
     
     var body: some Scene {
         WindowGroup {
-            RoomLogTab()
+            ContentView()
                 .environment(\.di, di)
         }
     }

--- a/RoomLog/RoomLog/Core/DIContainer/DIContainer.swift
+++ b/RoomLog/RoomLog/Core/DIContainer/DIContainer.swift
@@ -75,6 +75,13 @@ extension DIContainer {
         }
 
         // MARK: - UseCase Providers
+        container.register(AuthUseCaseProvider.self) {
+            AuthUseCaseProviderImpl(
+                adapter: container.resolve(MoyaNetworkAdapter.self),
+                tokenStore: container.resolve(TokenStore.self)
+            )
+        }
+
         container.register(HomeUseCaseProvider.self) {
             HomeUseCaseProviderImpl(adapter: container.resolve(MoyaNetworkAdapter.self))
         }

--- a/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum NavigationDestination: Hashable {
     enum Auth: Hashable {
-        case test
+        case signup
     }
     
     enum Home: Hashable {

--- a/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
@@ -32,8 +32,8 @@ private extension NavigationRoutingView {
     @ViewBuilder
     func authView(_ route: NavigationDestination.Auth) -> some View {
         switch route {
-        case .test:
-            Text("Auth Test View")
+        case .signup:
+            SignUpView()
         }
     }
     

--- a/RoomLog/RoomLog/Features/Auth/Data/DTO/AuthDTO.swift
+++ b/RoomLog/RoomLog/Features/Auth/Data/DTO/AuthDTO.swift
@@ -1,0 +1,72 @@
+//
+//  AuthDTO.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+// MARK: - Request DTO
+
+struct LoginRequestDTO: Encodable {
+    let email: String
+    let password: String
+}
+
+struct SignUpRequestDTO: Encodable {
+    let email: String
+    let password: String
+    let nickname: String
+}
+
+// MARK: - Response DTO
+
+struct LoginResponseDTO: Codable {
+    let userId: Int
+    let email: String
+    let nickname: String
+    let accessToken: String
+    let refreshToken: String
+    let tokenType: String
+
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case email
+        case nickname
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
+        case tokenType = "token_type"
+    }
+
+    func toDomain() -> AuthUser {
+        AuthUser(
+            userId: userId,
+            email: email,
+            nickname: nickname
+        )
+    }
+}
+
+struct SignUpResponseDTO: Codable {
+    let userId: Int
+    let email: String
+    let nickname: String
+    let createdAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case email
+        case nickname
+        case createdAt = "created_at"
+    }
+
+    func toDomain() -> SignedUpUser {
+        SignedUpUser(
+            userId: userId,
+            email: email,
+            nickname: nickname,
+            createdAt: Date.fromServerDateTime(createdAt) ?? Date()
+        )
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Data/Repositories/AuthRepository.swift
+++ b/RoomLog/RoomLog/Features/Auth/Data/Repositories/AuthRepository.swift
@@ -1,0 +1,45 @@
+//
+//  AuthRepository.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+import Moya
+
+final class AuthRepository: AuthRepositoryProtocol {
+    // MARK: - Property
+    private let adapter: MoyaNetworkAdapter
+    private let tokenStore: TokenStore
+    private let decoder: JSONDecoder
+
+    // MARK: - Init
+    init(adapter: MoyaNetworkAdapter, tokenStore: TokenStore, decoder: JSONDecoder = JSONDecoder()) {
+        self.adapter = adapter
+        self.tokenStore = tokenStore
+        self.decoder = decoder
+    }
+
+    // MARK: - Function
+    func login(email: String, password: String) async throws -> AuthUser {
+        let request = LoginRequestDTO(email: email, password: password)
+        let response = try await adapter.request(AuthTarget.login(request: request))
+        let dto = try decoder.decode(APIResponse<LoginResponseDTO>.self, from: response.data)
+        let result = try dto.unwrap()
+
+        try await tokenStore.save(
+            accessToken: result.accessToken,
+            refreshToken: result.refreshToken
+        )
+
+        return result.toDomain()
+    }
+
+    func signUp(email: String, password: String, nickname: String) async throws -> SignedUpUser {
+        let request = SignUpRequestDTO(email: email, password: password, nickname: nickname)
+        let response = try await adapter.request(AuthTarget.signup(request: request))
+        let dto = try decoder.decode(APIResponse<SignUpResponseDTO>.self, from: response.data)
+        return try dto.unwrap().toDomain()
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Data/Target/AuthTarget.swift
+++ b/RoomLog/RoomLog/Features/Auth/Data/Target/AuthTarget.swift
@@ -1,0 +1,39 @@
+//
+//  AuthTarget.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+import Moya
+internal import Alamofire
+
+enum AuthTarget {
+    case login(request: LoginRequestDTO)
+    case signup(request: SignUpRequestDTO)
+}
+
+extension AuthTarget: BaseTargetType {
+    var path: String {
+        switch self {
+        case .login:
+            return "/auth/login"
+        case .signup:
+            return "/auth/signup"
+        }
+    }
+
+    var method: Moya.Method {
+        .post
+    }
+
+    var task: Moya.Task {
+        switch self {
+        case .login(let request):
+            return .requestJSONEncodable(request)
+        case .signup(let request):
+            return .requestJSONEncodable(request)
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
+++ b/RoomLog/RoomLog/Features/Auth/Domain/Interfaces/AuthRepositoryProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  AuthRepositoryProtocol.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+protocol AuthRepositoryProtocol {
+    func login(email: String, password: String) async throws -> AuthUser
+    func signUp(email: String, password: String, nickname: String) async throws -> SignedUpUser
+}

--- a/RoomLog/RoomLog/Features/Auth/Domain/Models/AuthUser.swift
+++ b/RoomLog/RoomLog/Features/Auth/Domain/Models/AuthUser.swift
@@ -1,0 +1,21 @@
+//
+//  AuthUser.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+struct AuthUser {
+    let userId: Int
+    let email: String
+    let nickname: String
+}
+
+struct SignedUpUser {
+    let userId: Int
+    let email: String
+    let nickname: String
+    let createdAt: Date
+}

--- a/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Implementations/LoginUseCase.swift
+++ b/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Implementations/LoginUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  LoginUseCase.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+final class LoginUseCase: LoginUseCaseProtocol {
+    private let repository: AuthRepositoryProtocol
+
+    init(repository: AuthRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(email: String, password: String) async throws -> AuthUser {
+        try await repository.login(email: email, password: password)
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Implementations/SignUpUseCase.swift
+++ b/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Implementations/SignUpUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  SignUpUseCase.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+final class SignUpUseCase: SignUpUseCaseProtocol {
+    private let repository: AuthRepositoryProtocol
+
+    init(repository: AuthRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(email: String, password: String, nickname: String) async throws -> SignedUpUser {
+        try await repository.signUp(email: email, password: password, nickname: nickname)
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Protocols/LoginUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Protocols/LoginUseCaseProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  LoginUseCaseProtocol.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+protocol LoginUseCaseProtocol {
+    func execute(email: String, password: String) async throws -> AuthUser
+}

--- a/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Protocols/SignUpUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/Auth/Domain/UseCases/Protocols/SignUpUseCaseProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  SignUpUseCaseProtocol.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+protocol SignUpUseCaseProtocol {
+    func execute(email: String, password: String, nickname: String) async throws -> SignedUpUser
+}

--- a/RoomLog/RoomLog/Features/Auth/Presentation/Provider/AuthUseCaseProvider.swift
+++ b/RoomLog/RoomLog/Features/Auth/Presentation/Provider/AuthUseCaseProvider.swift
@@ -1,0 +1,32 @@
+//
+//  AuthUseCaseProvider.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+protocol AuthUseCaseProvider {
+    func makeLoginUseCase() -> LoginUseCaseProtocol
+    func makeSignUpUseCase() -> SignUpUseCaseProtocol
+}
+
+final class AuthUseCaseProviderImpl: AuthUseCaseProvider {
+    // MARK: - Repository
+    private let authRepository: AuthRepositoryProtocol
+
+    // MARK: - Init
+    init(adapter: MoyaNetworkAdapter, tokenStore: TokenStore) {
+        self.authRepository = AuthRepository(adapter: adapter, tokenStore: tokenStore)
+    }
+
+    // MARK: - Auth UseCases
+    func makeLoginUseCase() -> LoginUseCaseProtocol {
+        LoginUseCase(repository: authRepository)
+    }
+
+    func makeSignUpUseCase() -> SignUpUseCaseProtocol {
+        SignUpUseCase(repository: authRepository)
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Presentation/ViewModels/LoginViewModel.swift
+++ b/RoomLog/RoomLog/Features/Auth/Presentation/ViewModels/LoginViewModel.swift
@@ -1,0 +1,48 @@
+//
+//  LoginViewModel.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+@Observable
+final class LoginViewModel {
+    // MARK: - Input
+    var email: String = ""
+    var password: String = ""
+
+    // MARK: - State
+    var isLoading: Bool = false
+    var errorMessage: String?
+    var isLoggedIn: Bool = false
+
+    // MARK: - Dependencies
+    private let loginUseCase: LoginUseCaseProtocol
+
+    init(loginUseCase: LoginUseCaseProtocol) {
+        self.loginUseCase = loginUseCase
+    }
+
+    // MARK: - Actions
+    var isFormValid: Bool {
+        !email.isEmpty && !password.isEmpty
+    }
+
+    func login() async {
+        guard isFormValid else { return }
+
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            _ = try await loginUseCase.execute(email: email, password: password)
+            isLoggedIn = true
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
+++ b/RoomLog/RoomLog/Features/Auth/Presentation/ViewModels/SignUpViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  SignUpViewModel.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import Foundation
+
+@Observable
+final class SignUpViewModel {
+    // MARK: - Input
+    var email: String = ""
+    var password: String = ""
+    var nickname: String = ""
+
+    // MARK: - State
+    var isLoading: Bool = false
+    var errorMessage: String?
+    var isSignUpCompleted: Bool = false
+
+    // MARK: - Dependencies
+    private let signUpUseCase: SignUpUseCaseProtocol
+
+    init(signUpUseCase: SignUpUseCaseProtocol) {
+        self.signUpUseCase = signUpUseCase
+    }
+
+    // MARK: - Actions
+    var isFormValid: Bool {
+        !email.isEmpty && !password.isEmpty && !nickname.isEmpty
+    }
+
+    func signUp() async {
+        guard isFormValid else { return }
+
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            _ = try await signUpUseCase.execute(
+                email: email,
+                password: password,
+                nickname: nickname
+            )
+            isSignUpCompleted = true
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Presentation/Views/LoginView.swift
+++ b/RoomLog/RoomLog/Features/Auth/Presentation/Views/LoginView.swift
@@ -1,0 +1,116 @@
+//
+//  LoginView.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import SwiftUI
+
+struct LoginView: View {
+    @Environment(\.di) var di: DIContainer
+    @State private var viewModel: LoginViewModel?
+    @State private var showSignUp = false
+
+    var onLoginSuccess: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                Spacer()
+
+                // MARK: - Logo
+                Image("Logo")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 120)
+                    .padding(.bottom, 48)
+
+                // MARK: - Input Fields
+                if let viewModel {
+                    VStack(spacing: 16) {
+                        TextField("이메일", text: Bindable(viewModel).email)
+                            .textContentType(.emailAddress)
+                            .keyboardType(.emailAddress)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .padding(16)
+                            .background(Color("neutral50"))
+                            .cornerRadius(12)
+                            .font(.medium, 16)
+
+                        SecureField("비밀번호", text: Bindable(viewModel).password)
+                            .textContentType(.password)
+                            .padding(16)
+                            .background(Color("neutral50"))
+                            .cornerRadius(12)
+                            .font(.medium, 16)
+                    }
+                    .padding(.horizontal, 24)
+
+                    // MARK: - Error Message
+                    if let errorMessage = viewModel.errorMessage {
+                        Text(errorMessage)
+                            .foregroundStyle(.red)
+                            .font(.regular, 14)
+                            .padding(.top, 12)
+                            .padding(.horizontal, 24)
+                    }
+
+                    // MARK: - Login Button
+                    Button {
+                        Task { await viewModel.login() }
+                    } label: {
+                        Group {
+                            if viewModel.isLoading {
+                                ProgressView()
+                                    .tint(.white)
+                            } else {
+                                Text("로그인")
+                                    .font(.semibold, 16)
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 52)
+                        .foregroundStyle(.white)
+                        .background(viewModel.isFormValid ? Color("deepNavy") : Color("neutral300"))
+                        .cornerRadius(12)
+                    }
+                    .disabled(!viewModel.isFormValid || viewModel.isLoading)
+                    .padding(.horizontal, 24)
+                    .padding(.top, 24)
+
+                    // MARK: - Sign Up Link
+                    Button {
+                        showSignUp = true
+                    } label: {
+                        HStack(spacing: 4) {
+                            Text("계정이 없으신가요?")
+                                .foregroundStyle(Color("neutral500"))
+                            Text("회원가입")
+                                .foregroundStyle(Color("deepNavy"))
+                        }
+                        .font(.medium, 14)
+                    }
+                    .padding(.top, 16)
+                }
+
+                Spacer()
+            }
+            .navigationDestination(isPresented: $showSignUp) {
+                SignUpView()
+            }
+            .onChange(of: viewModel?.isLoggedIn) { _, newValue in
+                if newValue == true {
+                    onLoginSuccess()
+                }
+            }
+        }
+        .onAppear {
+            if viewModel == nil {
+                let provider = di.resolve(AuthUseCaseProvider.self)
+                viewModel = LoginViewModel(loginUseCase: provider.makeLoginUseCase())
+            }
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Auth/Presentation/Views/SignUpView.swift
+++ b/RoomLog/RoomLog/Features/Auth/Presentation/Views/SignUpView.swift
@@ -85,17 +85,6 @@ struct SignUpView: View {
 
             Spacer()
         }
-        .navigationBarBackButtonHidden(true)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button {
-                    dismiss()
-                } label: {
-                    Image(systemName: "chevron.left")
-                        .foregroundStyle(Color("neutral900"))
-                }
-            }
-        }
         .onChange(of: viewModel?.isSignUpCompleted) { _, newValue in
             if newValue == true {
                 dismiss()

--- a/RoomLog/RoomLog/Features/Auth/Presentation/Views/SignUpView.swift
+++ b/RoomLog/RoomLog/Features/Auth/Presentation/Views/SignUpView.swift
@@ -1,0 +1,111 @@
+//
+//  SignUpView.swift
+//  RoomLog
+//
+//  Created by 김도연 on 4/30/26.
+//
+
+import SwiftUI
+
+struct SignUpView: View {
+    @Environment(\.di) var di: DIContainer
+    @Environment(\.dismiss) var dismiss
+    @State private var viewModel: SignUpViewModel?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            // MARK: - Title
+            Text("회원가입")
+                .font(.bold, 24)
+                .foregroundStyle(Color("neutral900"))
+                .padding(.bottom, 32)
+
+            // MARK: - Input Fields
+            if let viewModel {
+                VStack(spacing: 16) {
+                    TextField("이메일", text: Bindable(viewModel).email)
+                        .textContentType(.emailAddress)
+                        .keyboardType(.emailAddress)
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                        .padding(16)
+                        .background(Color("neutral50"))
+                        .cornerRadius(12)
+                        .font(.medium, 16)
+
+                    SecureField("비밀번호", text: Bindable(viewModel).password)
+                        .textContentType(.newPassword)
+                        .padding(16)
+                        .background(Color("neutral50"))
+                        .cornerRadius(12)
+                        .font(.medium, 16)
+
+                    TextField("닉네임", text: Bindable(viewModel).nickname)
+                        .padding(16)
+                        .background(Color("neutral50"))
+                        .cornerRadius(12)
+                        .font(.medium, 16)
+                }
+                .padding(.horizontal, 24)
+
+                // MARK: - Error Message
+                if let errorMessage = viewModel.errorMessage {
+                    Text(errorMessage)
+                        .foregroundStyle(.red)
+                        .font(.regular, 14)
+                        .padding(.top, 12)
+                        .padding(.horizontal, 24)
+                }
+
+                // MARK: - Sign Up Button
+                Button {
+                    Task { await viewModel.signUp() }
+                } label: {
+                    Group {
+                        if viewModel.isLoading {
+                            ProgressView()
+                                .tint(.white)
+                        } else {
+                            Text("회원가입")
+                                .font(.semibold, 16)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 52)
+                    .foregroundStyle(.white)
+                    .background(viewModel.isFormValid ? Color("deepNavy") : Color("neutral300"))
+                    .cornerRadius(12)
+                }
+                .disabled(!viewModel.isFormValid || viewModel.isLoading)
+                .padding(.horizontal, 24)
+                .padding(.top, 24)
+            }
+
+            Spacer()
+        }
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .foregroundStyle(Color("neutral900"))
+                }
+            }
+        }
+        .onChange(of: viewModel?.isSignUpCompleted) { _, newValue in
+            if newValue == true {
+                dismiss()
+            }
+        }
+        .onAppear {
+            if viewModel == nil {
+                let provider = di.resolve(AuthUseCaseProvider.self)
+                viewModel = SignUpViewModel(signUpUseCase: provider.makeSignUpUseCase())
+            }
+        }
+    }
+}


### PR DESCRIPTION
## ✨ PR 유형
- [x] feature

<br>

## 🛠️ 작업 내용
- `AuthDTO`: 로그인/회원가입 요청·응답 DTO
- `AuthTarget`: Moya TargetType (`/auth/login`, `/auth/signup`)
- `AuthRepository`: 로그인 시 토큰 자동 저장 포함
- `AuthUser`, `SignedUpUser` 도메인 모델
- `LoginUseCase`, `SignUpUseCase` 및 프로토콜


## 🔍 관련 이슈
- closed #31 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그인 및 회원가입 기능 추가
  * 앱 시작 시 로그인 상태 자동 확인
  * 로그인 상태에 따라 로그인 화면 또는 메인 앱 표시
  * 이메일, 비밀번호 기반 인증 지원
  * 로딩 상태 및 오류 메시지 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->