### PR TITLE
[Design] tabBar 디자인 반영

### DIFF
--- a/RoomLog/RoomLog/Features/Tab/Presentation/RoomLogTab.swift
+++ b/RoomLog/RoomLog/Features/Tab/Presentation/RoomLogTab.swift
@@ -13,16 +13,17 @@ struct RoomLogTab: View {
     // MARK: - Property
     @State var isShowMyPage: Bool = false
     @Environment(\.di) var di
-    
+    @Environment(\.colorScheme) var colorScheme
+
     // MARK: - Body
     var body: some View {
         let pathStore = di.resolve(PathStore.self)
-        
+
         TabView {
-            Tab("", systemImage: "house") {
+            Tab("Home", systemImage: "house") {
                 Text("Home")
             }
-            Tab("", systemImage: "wrench.and.screwdriver.fill") {
+            Tab("Viewer", systemImage: "magnifyingglass") {
                 NavigationStack(path: Bindable(pathStore).defectPath) {
                     ViewerView()
                         .navigationDestination(for: NavigationDestination.self) {
@@ -30,11 +31,11 @@ struct RoomLogTab: View {
                         }
                 }
             }
-            Tab("", systemImage: "person.fill", role: .search) {
+            Tab("Profile", systemImage: "person.fill") {
                 Text("MyPage")
             }
         }
-        .tabBarMinimizeBehavior(.onScrollDown)
+        .tint(colorScheme == .dark ? .cloudDancer : .mutedBlue)
     }
 }
 


### PR DESCRIPTION
- 기존 탭바 배경 색상 변경이 불가하여 선택 시 색상만 수정
- 다크모드일 경우 원래 디자인과 동일한 디자인 사용

## ✨ PR 유형
- [x] design

<br>

## 🛠️ 작업 내용
- TabBar Design 반영
- Light mode에선 TabBar 배경 색상 변경이 불가능해 배열만 반영 (추후 색상 수정 가능)
- Dark mode 이용 시 Figma 디자인 그대로 반영 완료

<br>

## 🔍 관련 이슈
- closed #39 

<br>

## 📸 스크린샷 - UI작업인 경우만 추가
<img width="229" height="63" alt="스크린샷 2026-05-03 19 19 44" src="https://github.com/user-attachments/assets/15e5053a-136b-48c4-b533-37ca68924216" />
<img width="246" height="85" alt="스크린샷 2026-05-03 19 19 38" src="https://github.com/user-attachments/assets/dbd9c2b9-38e3-4f42-99b3-9230ce577cc7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 다크 모드 및 라이트 모드에 따른 탭 표시 줄 색상 자동 조정 기능 추가

* **개선 사항**
  * 탭 레이블을 명확한 제목으로 업데이트 (홈, 뷰어, 프로필)
  * 뷰어 탭 아이콘 변경
  * 탭 표시 줄 UI 동작 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->