### PR TITLE
[Feat] 마이페이지 구현 (API 연동 + UI)

### DIFF
--- a/RoomLog/RoomLog/Features/MyPage/Data/DTO/UserDTO.swift
+++ b/RoomLog/RoomLog/Features/MyPage/Data/DTO/UserDTO.swift
@@ -7,6 +7,14 @@
 
 import Foundation
 
+// MARK: - Request DTO
+
+struct UpdateUserRequestDTO: Encodable {
+    let nickname: String
+}
+
+// MARK: - Response DTO
+
 struct UserResponseDTO: Codable {
     let userId: Int
     let nickname: String
@@ -27,5 +35,25 @@ struct UserResponseDTO: Codable {
             email: email,
             createdAt: Date.fromServerDateTime(createdAt) ?? Date()
         )
+    }
+}
+
+struct UpdateUserResponseDTO: Codable {
+    let userId: Int
+    let nickname: String
+
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case nickname
+    }
+}
+
+struct DeleteUserResponseDTO: Codable {
+    let userId: Int
+    let deleted: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case deleted
     }
 }

--- a/RoomLog/RoomLog/Features/MyPage/Data/Repositories/MyPageRepository.swift
+++ b/RoomLog/RoomLog/Features/MyPage/Data/Repositories/MyPageRepository.swift
@@ -29,4 +29,17 @@ final class MyPageRepository: MyPageRepositoryProtocol {
             throw RepositoryError.decodingError(detail: String(describing: error))
         }
     }
+
+    func updateUser(nickname: String) async throws {
+        let request = UpdateUserRequestDTO(nickname: nickname)
+        let response = try await adapter.request(UserTarget.updateUser(request: request))
+        let dto = try decoder.decode(APIResponse<UpdateUserResponseDTO>.self, from: response.data)
+        _ = try dto.unwrap()
+    }
+
+    func deleteUser() async throws {
+        let response = try await adapter.request(UserTarget.deleteUser)
+        let dto = try decoder.decode(APIResponse<DeleteUserResponseDTO>.self, from: response.data)
+        _ = try dto.unwrap()
+    }
 }

--- a/RoomLog/RoomLog/Features/MyPage/Data/Repositories/MyPageRepository.swift
+++ b/RoomLog/RoomLog/Features/MyPage/Data/Repositories/MyPageRepository.swift
@@ -33,13 +33,21 @@ final class MyPageRepository: MyPageRepositoryProtocol {
     func updateUser(nickname: String) async throws {
         let request = UpdateUserRequestDTO(nickname: nickname)
         let response = try await adapter.request(UserTarget.updateUser(request: request))
-        let dto = try decoder.decode(APIResponse<UpdateUserResponseDTO>.self, from: response.data)
-        _ = try dto.unwrap()
+        do {
+            let dto = try decoder.decode(APIResponse<UpdateUserResponseDTO>.self, from: response.data)
+            _ = try dto.unwrap()
+        } catch let error as DecodingError {
+            throw RepositoryError.decodingError(detail: String(describing: error))
+        }
     }
 
     func deleteUser() async throws {
         let response = try await adapter.request(UserTarget.deleteUser)
-        let dto = try decoder.decode(APIResponse<DeleteUserResponseDTO>.self, from: response.data)
-        _ = try dto.unwrap()
+        do {
+            let dto = try decoder.decode(APIResponse<DeleteUserResponseDTO>.self, from: response.data)
+            _ = try dto.unwrap()
+        } catch let error as DecodingError {
+            throw RepositoryError.decodingError(detail: String(describing: error))
+        }
     }
 }

--- a/RoomLog/RoomLog/Features/MyPage/Data/Target/UserTarget.swift
+++ b/RoomLog/RoomLog/Features/MyPage/Data/Target/UserTarget.swift
@@ -11,12 +11,14 @@ internal import Alamofire
 
 enum UserTarget {
     case getUser
+    case updateUser(request: UpdateUserRequestDTO)
+    case deleteUser
 }
 
 extension UserTarget: BaseTargetType {
     var path: String {
         switch self {
-        case .getUser:
+        case .getUser, .updateUser, .deleteUser:
             return "/user"
         }
     }
@@ -25,13 +27,19 @@ extension UserTarget: BaseTargetType {
         switch self {
         case .getUser:
             return .get
+        case .updateUser:
+            return .patch
+        case .deleteUser:
+            return .delete
         }
     }
 
     var task: Moya.Task {
         switch self {
-        case .getUser:
+        case .getUser, .deleteUser:
             return .requestPlain
+        case .updateUser(let request):
+            return .requestJSONEncodable(request)
         }
     }
 }

--- a/RoomLog/RoomLog/Features/MyPage/Domain/Interfaces/MyPageRepositoryProtocol.swift
+++ b/RoomLog/RoomLog/Features/MyPage/Domain/Interfaces/MyPageRepositoryProtocol.swift
@@ -10,4 +10,8 @@ import Foundation
 protocol MyPageRepositoryProtocol {
     /// 유저 정보 조회
     func getUser() async throws -> User
+    /// 닉네임 수정
+    func updateUser(nickname: String) async throws
+    /// 회원 탈퇴
+    func deleteUser() async throws
 }

--- a/RoomLog/RoomLog/Features/MyPage/Domain/UseCases/DeleteUserUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/MyPage/Domain/UseCases/DeleteUserUseCaseProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  DeleteUserUseCaseProtocol.swift
+//  RoomLog
+//
+//  Created by 김도연 on 5/12/26.
+//
+
+import Foundation
+
+/// 회원 탈퇴 UseCase
+protocol DeleteUserUseCaseProtocol {
+    func execute() async throws
+}

--- a/RoomLog/RoomLog/Features/MyPage/Domain/UseCases/Implementations/DeleteUserUseCase.swift
+++ b/RoomLog/RoomLog/Features/MyPage/Domain/UseCases/Implementations/DeleteUserUseCase.swift
@@ -1,0 +1,21 @@
+//
+//  DeleteUserUseCase.swift
+//  RoomLog
+//
+//  Created by 김도연 on 5/12/26.
+//
+
+import Foundation
+
+final class DeleteUserUseCase: DeleteUserUseCaseProtocol {
+
+    private let repository: MyPageRepositoryProtocol
+
+    init(repository: MyPageRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute() async throws {
+        try await repository.deleteUser()
+    }
+}

--- a/RoomLog/RoomLog/Features/MyPage/Domain/UseCases/Implementations/UpdateUserUseCase.swift
+++ b/RoomLog/RoomLog/Features/MyPage/Domain/UseCases/Implementations/UpdateUserUseCase.swift
@@ -1,0 +1,21 @@
+//
+//  UpdateUserUseCase.swift
+//  RoomLog
+//
+//  Created by 김도연 on 5/12/26.
+//
+
+import Foundation
+
+final class UpdateUserUseCase: UpdateUserUseCaseProtocol {
+
+    private let repository: MyPageRepositoryProtocol
+
+    init(repository: MyPageRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(nickname: String) async throws {
+        try await repository.updateUser(nickname: nickname)
+    }
+}

--- a/RoomLog/RoomLog/Features/MyPage/Domain/UseCases/UpdateUserUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/MyPage/Domain/UseCases/UpdateUserUseCaseProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  UpdateUserUseCaseProtocol.swift
+//  RoomLog
+//
+//  Created by 김도연 on 5/12/26.
+//
+
+import Foundation
+
+/// 닉네임 수정 UseCase
+protocol UpdateUserUseCaseProtocol {
+    func execute(nickname: String) async throws
+}

--- a/RoomLog/RoomLog/Features/MyPage/Presentation/Provider/MyPageUseCaseProvider.swift
+++ b/RoomLog/RoomLog/Features/MyPage/Presentation/Provider/MyPageUseCaseProvider.swift
@@ -9,6 +9,8 @@ import Foundation
 
 protocol MyPageUseCaseProvider {
     func makeGetUserUseCase() -> GetUserUseCaseProtocol
+    func makeUpdateUserUseCase() -> UpdateUserUseCaseProtocol
+    func makeDeleteUserUseCase() -> DeleteUserUseCaseProtocol
 }
 
 final class MyPageUseCaseProviderImpl: MyPageUseCaseProvider {
@@ -23,5 +25,13 @@ final class MyPageUseCaseProviderImpl: MyPageUseCaseProvider {
     // MARK: - MyPage UseCases
     func makeGetUserUseCase() -> GetUserUseCaseProtocol {
         GetUserUseCase(repository: myPageRepository)
+    }
+
+    func makeUpdateUserUseCase() -> UpdateUserUseCaseProtocol {
+        UpdateUserUseCase(repository: myPageRepository)
+    }
+
+    func makeDeleteUserUseCase() -> DeleteUserUseCaseProtocol {
+        DeleteUserUseCase(repository: myPageRepository)
     }
 }

--- a/RoomLog/RoomLog/Features/MyPage/Presentation/ViewModels/MyPageViewModel.swift
+++ b/RoomLog/RoomLog/Features/MyPage/Presentation/ViewModels/MyPageViewModel.swift
@@ -18,7 +18,8 @@ final class MyPageViewModel {
 
     private(set) var user: User?
     private(set) var isLoading: Bool = false
-    private(set) var errorMessage: String?
+    var errorMessage: String?
+    var showError: Bool = false
 
     var showEditNicknameAlert: Bool = false
     var editingNickname: String = ""
@@ -41,6 +42,7 @@ final class MyPageViewModel {
             user = try await provider.makeGetUserUseCase().execute()
         } catch {
             errorMessage = error.localizedDescription
+            showError = true
         }
         isLoading = false
     }
@@ -55,15 +57,19 @@ final class MyPageViewModel {
             editingNickname = ""
         } catch {
             errorMessage = error.localizedDescription
+            showError = true
         }
     }
 
     @MainActor
-    func deleteAccount() async {
+    func deleteAccount() async -> Bool {
         do {
             try await provider.makeDeleteUserUseCase().execute()
+            return true
         } catch {
             errorMessage = error.localizedDescription
+            showError = true
+            return false
         }
     }
 }

--- a/RoomLog/RoomLog/Features/MyPage/Presentation/ViewModels/MyPageViewModel.swift
+++ b/RoomLog/RoomLog/Features/MyPage/Presentation/ViewModels/MyPageViewModel.swift
@@ -1,0 +1,69 @@
+//
+//  MyPageViewModel.swift
+//  RoomLog
+//
+//  Created by 김도연 on 5/12/26.
+//
+
+import Foundation
+
+@Observable
+final class MyPageViewModel {
+
+    // MARK: - Provider
+
+    private let provider: MyPageUseCaseProvider
+
+    // MARK: - State
+
+    private(set) var user: User?
+    private(set) var isLoading: Bool = false
+    private(set) var errorMessage: String?
+
+    var showEditNicknameAlert: Bool = false
+    var editingNickname: String = ""
+    var showDeleteAccountConfirm: Bool = false
+    var showLogoutConfirm: Bool = false
+
+    // MARK: - Init
+
+    init(provider: MyPageUseCaseProvider) {
+        self.provider = provider
+    }
+
+    // MARK: - Actions
+
+    @MainActor
+    func fetchUser() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            user = try await provider.makeGetUserUseCase().execute()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    @MainActor
+    func updateNickname() async {
+        let trimmed = editingNickname.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        do {
+            try await provider.makeUpdateUserUseCase().execute(nickname: trimmed)
+            user = try await provider.makeGetUserUseCase().execute()
+            editingNickname = ""
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    func deleteAccount() async {
+        do {
+            try await provider.makeDeleteUserUseCase().execute()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/MyPage/Presentation/Views/MyPageView.swift
+++ b/RoomLog/RoomLog/Features/MyPage/Presentation/Views/MyPageView.swift
@@ -63,12 +63,20 @@ struct MyPageView: View {
             Button("취소", role: .cancel) {}
             Button("탈퇴", role: .destructive) {
                 Task {
-                    await viewModel.deleteAccount()
-                    appFlow.logout()
+                    if await viewModel.deleteAccount() {
+                        appFlow.logout()
+                    }
                 }
             }
         } message: {
             Text("탈퇴하면 모든 데이터가 삭제되며\n복구할 수 없습니다.")
+        }
+        .alert("오류", isPresented: $viewModel.showError) {
+            Button("확인") {}
+        } message: {
+            if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+            }
         }
     }
 }

--- a/RoomLog/RoomLog/Features/MyPage/Presentation/Views/MyPageView.swift
+++ b/RoomLog/RoomLog/Features/MyPage/Presentation/Views/MyPageView.swift
@@ -8,21 +8,239 @@
 import SwiftUI
 
 struct MyPageView: View {
+
     @Environment(\.appFlow) private var appFlow
+    @State private var viewModel: MyPageViewModel
+
+    init(provider: MyPageUseCaseProvider) {
+        self._viewModel = .init(
+            wrappedValue: MyPageViewModel(provider: provider)
+        )
+    }
 
     var body: some View {
-        List {
-            Section {
-                Button(role: .destructive) {
-                    appFlow.logout()
-                } label: {
-                    HStack {
-                        Image(systemName: "rectangle.portrait.and.arrow.right")
-                        Text("로그아웃")
-                    }
-                }
+        ScrollView {
+            VStack(spacing: 32) {
+                profileCard
+                menuSection
+                infoSection
+                accountSection
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            .padding(.bottom, 40)
+        }
+        .scrollIndicators(.hidden)
+        .toolbar {
+            ToolbarItem(placement: .title) {
+                Image(.logo)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 128)
+                    .padding(.top)
             }
         }
-        .navigationTitle("마이페이지")
+        .task { await viewModel.fetchUser() }
+        .alert("닉네임 변경", isPresented: $viewModel.showEditNicknameAlert) {
+            TextField("새로운 닉네임", text: $viewModel.editingNickname)
+            Button("취소", role: .cancel) {
+                viewModel.editingNickname = ""
+            }
+            Button("변경") {
+                Task { await viewModel.updateNickname() }
+            }
+            .keyboardShortcut(.defaultAction)
+        }
+        .alert("로그아웃", isPresented: $viewModel.showLogoutConfirm) {
+            Button("취소", role: .cancel) {}
+            Button("로그아웃", role: .destructive) {
+                appFlow.logout()
+            }
+        } message: {
+            Text("정말 로그아웃 하시겠습니까?")
+        }
+        .alert("회원 탈퇴", isPresented: $viewModel.showDeleteAccountConfirm) {
+            Button("취소", role: .cancel) {}
+            Button("탈퇴", role: .destructive) {
+                Task {
+                    await viewModel.deleteAccount()
+                    appFlow.logout()
+                }
+            }
+        } message: {
+            Text("탈퇴하면 모든 데이터가 삭제되며\n복구할 수 없습니다.")
+        }
+    }
+}
+
+// MARK: - Profile Card
+
+private extension MyPageView {
+    var profileCard: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "person.crop.circle.fill")
+                .font(.system(size: 72))
+                .foregroundStyle(.blueGray300)
+
+            if let user = viewModel.user {
+                VStack(spacing: 6) {
+                    Text(user.nickname)
+                        .font(.bold, 24)
+                        .foregroundStyle(.deepNavy)
+                    Text(user.email)
+                        .font(.regular, 14)
+                        .foregroundStyle(.blueGray500)
+                }
+            } else if viewModel.isLoading {
+                ProgressView()
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 32)
+        .background(.white, in: RoundedRectangle(cornerRadius: 20))
+        .shadow(color: .black.opacity(0.08), radius: 8, y: 2)
+    }
+}
+
+// MARK: - Menu Section
+
+private extension MyPageView {
+    var menuSection: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("설정")
+                .font(.semibold, 20)
+                .foregroundStyle(.neutral800)
+
+            VStack(spacing: 0) {
+                menuRow(icon: "pencil", title: "닉네임 변경") {
+                    viewModel.editingNickname = viewModel.user?.nickname ?? ""
+                    viewModel.showEditNicknameAlert = true
+                }
+
+                Divider().padding(.horizontal, 16)
+
+                menuRow(icon: "camera", title: "카메라 권한 설정") {
+                    openAppSettings()
+                }
+            }
+            .background(.white, in: RoundedRectangle(cornerRadius: 20))
+            .shadow(color: .black.opacity(0.08), radius: 8, y: 2)
+        }
+    }
+
+    func menuRow(icon: String, title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 14) {
+                Image(systemName: icon)
+                    .font(.system(size: 16))
+                    .foregroundStyle(.mutedBlue)
+                    .frame(width: 24)
+                Text(title)
+                    .font(.medium, 16)
+                    .foregroundStyle(.neutral800)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.blueGray300)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 16)
+            .contentShape(Rectangle())
+        }
+    }
+}
+
+// MARK: - Info Section
+
+private extension MyPageView {
+    var infoSection: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("정보")
+                .font(.semibold, 20)
+                .foregroundStyle(.neutral800)
+
+            VStack(spacing: 0) {
+                infoRow(icon: "info.circle", title: "앱 버전", value: appVersion)
+
+                if let user = viewModel.user {
+                    Divider().padding(.horizontal, 16)
+                    infoRow(
+                        icon: "calendar",
+                        title: "가입일",
+                        value: user.createdAt.formatted(date: .abbreviated, time: .omitted)
+                    )
+                }
+            }
+            .background(.white, in: RoundedRectangle(cornerRadius: 20))
+            .shadow(color: .black.opacity(0.08), radius: 8, y: 2)
+        }
+    }
+
+    func infoRow(icon: String, title: String, value: String) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: icon)
+                .font(.system(size: 16))
+                .foregroundStyle(.mutedBlue)
+                .frame(width: 24)
+            Text(title)
+                .font(.medium, 16)
+                .foregroundStyle(.neutral800)
+            Spacer()
+            Text(value)
+                .font(.regular, 14)
+                .foregroundStyle(.blueGray500)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+    }
+}
+
+// MARK: - Account Section
+
+private extension MyPageView {
+    var accountSection: some View {
+        VStack(spacing: 0) {
+            menuRow(icon: "rectangle.portrait.and.arrow.right", title: "로그아웃") {
+                viewModel.showLogoutConfirm = true
+            }
+
+            Divider().padding(.horizontal, 16)
+
+            Button {
+                viewModel.showDeleteAccountConfirm = true
+            } label: {
+                HStack(spacing: 14) {
+                    Image(systemName: "person.slash")
+                        .font(.system(size: 16))
+                        .foregroundStyle(.red.opacity(0.7))
+                        .frame(width: 24)
+                    Text("회원 탈퇴")
+                        .font(.medium, 16)
+                        .foregroundStyle(.red.opacity(0.7))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.blueGray300)
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 16)
+                .contentShape(Rectangle())
+            }
+        }
+        .background(.white, in: RoundedRectangle(cornerRadius: 20))
+        .shadow(color: .black.opacity(0.08), radius: 8, y: 2)
+    }
+}
+
+// MARK: - Helpers
+
+private extension MyPageView {
+    func openAppSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+
+    var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "-"
     }
 }

--- a/RoomLog/RoomLog/Features/Tab/Presentation/RoomLogTab.swift
+++ b/RoomLog/RoomLog/Features/Tab/Presentation/RoomLogTab.swift
@@ -42,7 +42,7 @@ struct RoomLogTab: View {
             }
             Tab("Profile", systemImage: "person.fill", value: .profile) {
                 NavigationStack {
-                    MyPageView()
+                    MyPageView(provider: di.resolve(MyPageUseCaseProvider.self))
                 }
             }
         }


### PR DESCRIPTION
## ✨ PR 유형
- [x] 마이페이지 기능 구현 (Data/Domain/Presentation 전체)

<br>

## 🛠️ 작업 내용
- UserTarget에 `updateUser` (PATCH /user), `deleteUser` (DELETE /user) 엔드포인트 추가
- Request/Response DTO 추가 (UpdateUserRequestDTO, UpdateUserResponseDTO, DeleteUserResponseDTO)
- MyPageRepository에 닉네임 수정, 회원 탈퇴 구현
- UpdateUserUseCase, DeleteUserUseCase 생성 및 Provider 등록
- MyPageViewModel 생성 (프로필 조회, 닉네임 수정, 회원 탈퇴)
- MyPageView 커스텀 UI 구현
  - 프로필 카드 (닉네임 + 이메일)
  - 설정 섹션 (닉네임 변경, 카메라 권한 설정)
  - 정보 섹션 (앱 버전, 가입일)
  - 계정 섹션 (로그아웃, 회원 탈퇴)
- RoomLogTab에서 MyPageUseCaseProvider DI 주입

<br>

## 🔍 관련 이슈
- closed #57

<br>

## 📸 스크린샷 - UI작업인 경우만 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 닉네임 변경: 프로필 정보에서 닉네임을 변경할 수 있습니다
  * 계정 삭제: 계정 설정에서 서비스 탈퇴를 할 수 있습니다

* **개선사항**
  * 마이페이지 화면 UI가 개편되어 더욱 직관적으로 개선되었습니다

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DGU-Team404/roomlog-ios/pull/58)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->