### PR TITLE
[Feat] 스캔 미리보기에서 방 저장 UI 연결

### DIFF
--- a/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
@@ -16,7 +16,7 @@ enum NavigationDestination: Hashable {
         case roomList(houseId: Int, houseName: String)
         case roomDetail(roomId: Int)
         case scan(houseId: Int, scanType: String)
-        case plyPreview(fileURL: URL)
+        case plyPreview(fileURL: URL, scanId: Int, houseId: Int)
         case houseList
     }
     

--- a/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
@@ -59,11 +59,8 @@ private extension NavigationRoutingView {
                     _ = pathStore.homePath.popLast()
                 }
             )
-        case .plyPreview(let fileURL):
-            PLYSceneView(fileURL: fileURL)
-                .ignoresSafeArea(edges: .bottom)
-                .navigationTitle("3D 미리보기")
-                .navigationBarTitleDisplayMode(.inline)
+        case .plyPreview(let fileURL, let scanId, let houseId):
+            ScanPreviewView(fileURL: fileURL, scanId: scanId, houseId: houseId)
         case .houseList:
             HouseListView(provider: provider)
         }

--- a/RoomLog/RoomLog/Features/Home/Presentation/Views/HomeView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Views/HomeView.swift
@@ -74,14 +74,11 @@ struct HomeView: View {
             Button("취소", role: .cancel) {
                 viewModel.newHouseName = ""
             }
-            Button {
+            Button("만들기") {
                 Task {
                     await viewModel.createHouse()
                     homeState.hasHouses = !viewModel.houses.isEmpty
                 }
-            } label: {
-                 Text("만들기")
-                    .tint(.white)
             }
             .keyboardShortcut(.defaultAction)
         }

--- a/RoomLog/RoomLog/Features/Home/Presentation/Views/RoomListView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Views/RoomListView.swift
@@ -284,7 +284,11 @@ struct RoomListView: View {
             phase: active.phase,
             onPreview: { fileURL in
                 showProcessingStatus = false
-                pathStore.homePath.append(.home(.plyPreview(fileURL: fileURL)))
+                pathStore.homePath.append(.home(.plyPreview(
+                    fileURL: fileURL,
+                    scanId: active.scanId,
+                    houseId: active.houseId
+                )))
             },
             onCancel: {
                 processingManager.cancel()

--- a/RoomLog/RoomLog/Features/Scan/Presentation/Views/Previews/ScanPreviewViewPreviews.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/Views/Previews/ScanPreviewViewPreviews.swift
@@ -1,0 +1,17 @@
+//
+//  ScanPreviewViewPreviews.swift
+//  RoomLog
+//
+//  Created by 김도연 on 5/14/26.
+//
+
+#if DEBUG
+import SwiftUI
+
+#Preview("3D 미리보기") {
+    NavigationStack {
+        ScanPreviewView(preview: true)
+    }
+}
+
+#endif

--- a/RoomLog/RoomLog/Features/Scan/Presentation/Views/ScanPreviewView.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/Views/ScanPreviewView.swift
@@ -1,0 +1,136 @@
+//
+//  ScanPreviewView.swift
+//  RoomLog
+//
+//  Created by 김도연 on 5/14/26.
+//
+
+import SwiftUI
+
+struct ScanPreviewView: View {
+
+    let fileURL: URL
+    let scanId: Int
+    let houseId: Int
+    private var isPreview: Bool = false
+
+    @Environment(\.di) private var di
+    @State private var showSaveAlert: Bool = false
+    @State private var showRescanAlert: Bool = false
+    @State private var roomName: String = ""
+    @State private var isSaving: Bool = false
+    @State private var errorMessage: String?
+
+    #if DEBUG
+    init(preview: Bool) {
+        self.fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("preview.ply")
+        self.scanId = 1
+        self.houseId = 1
+        self.isPreview = true
+    }
+    #endif
+
+    init(fileURL: URL, scanId: Int, houseId: Int) {
+        self.fileURL = fileURL
+        self.scanId = scanId
+        self.houseId = houseId
+    }
+
+    private var provider: HomeUseCaseProvider {
+        di.resolve(HomeUseCaseProvider.self)
+    }
+
+    private var processingManager: ScanProcessingManager {
+        di.resolve(ScanProcessingManager.self)
+    }
+
+    private var pathStore: PathStore {
+        di.resolve(PathStore.self)
+    }
+
+    var body: some View {
+        ZStack {
+            PLYSceneView(fileURL: fileURL)
+                .ignoresSafeArea(edges: .bottom)
+
+            if isSaving {
+                Color.black.opacity(0.3)
+                    .ignoresSafeArea()
+                ProgressView("저장 중...")
+                    .padding(24)
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+            }
+        }
+        .navigationTitle("3D 미리보기")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("다시 스캔") {
+                    showRescanAlert = true
+                }
+                .disabled(isSaving)
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("저장하기") {
+                    roomName = ""
+                    showSaveAlert = true
+                }
+                .disabled(isSaving)
+            }
+        }
+        .tint(.accent)
+        .alert("방 이름 입력", isPresented: $showSaveAlert) {
+            TextField("예: 거실, 안방", text: $roomName)
+            Button("취소", role: .cancel) {}
+            Button("저장") {
+                Task { await saveRoom() }
+            }
+            .disabled(roomName.trimmingCharacters(in: .whitespaces).isEmpty)
+            .keyboardShortcut(.defaultAction)
+        } message: {
+            Text("저장할 방의 이름을 입력해주세요")
+        }
+        .alert("다시 스캔하기", isPresented: $showRescanAlert) {
+            Button("취소", role: .cancel) {}
+            Button("다시 스캔", role: .destructive) {
+                processingManager.clear()
+                pathStore.homePath.removeLast(pathStore.homePath.count)
+            }
+        } message: {
+            Text("현재 스캔 결과를 폐기하고\n방 목록으로 돌아갑니다")
+        }
+        .alert("저장 실패", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("확인", role: .cancel) {}
+        } message: {
+            if let errorMessage {
+                Text(errorMessage)
+            }
+        }
+    }
+
+    // MARK: - Save
+
+    @MainActor
+    private func saveRoom() async {
+        let name = roomName.trimmingCharacters(in: .whitespaces)
+        guard !name.isEmpty else { return }
+
+        isSaving = true
+        do {
+            try await provider.makeCreateRoomUseCase().execute(
+                houseId: houseId,
+                name: name,
+                scanId: scanId
+            )
+            processingManager.clear()
+            pathStore.homePath.removeLast(pathStore.homePath.count)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isSaving = false
+    }
+}

--- a/RoomLog/RoomLog/Features/Scan/Presentation/Views/ScanPreviewView.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/Views/ScanPreviewView.swift
@@ -95,7 +95,7 @@ struct ScanPreviewView: View {
             Button("취소", role: .cancel) {}
             Button("다시 스캔", role: .destructive) {
                 processingManager.clear()
-                pathStore.homePath.removeLast(pathStore.homePath.count)
+                _ = pathStore.homePath.popLast()
             }
         } message: {
             Text("현재 스캔 결과를 폐기하고\n방 목록으로 돌아갑니다")
@@ -127,7 +127,7 @@ struct ScanPreviewView: View {
                 scanId: scanId
             )
             processingManager.clear()
-            pathStore.homePath.removeLast(pathStore.homePath.count)
+            _ = pathStore.homePath.popLast()
         } catch {
             errorMessage = error.localizedDescription
         }


### PR DESCRIPTION
## ✨ PR 유형
- [x] 스캔 미리보기 화면에서 방 저장 및 다시 스캔 기능 추가

<br>

## 🛠️ 작업 내용
- ScanPreviewView 생성 (PLYSceneView 래핑 + 저장하기/다시 스캔 툴바 버튼)
- NavigationDestination.plyPreview에 scanId, houseId 파라미터 추가
- NavigationRoutingView에서 ScanPreviewView로 라우팅 연결
- RoomListView에서 scanId, houseId 전달하도록 수정
- ScanPreviewView Preview 추가

<br>

## 🔍 관련 이슈
- closed #61

<br>

## 📸 스크린샷 - UI작업인 경우만 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 3D 스캔 미리보기에서 스캔 결과를 저장하거나 다시 스캔할 수 있는 기능 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DGU-Team404/roomlog-ios/pull/62)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->