### PR TITLE
[Feat] HouseListView 집 이미지 houseId 기반 배정

### DIFF
--- a/RoomLog/RoomLog/Features/Home/Presentation/Components/HouseImageView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Components/HouseImageView.swift
@@ -14,11 +14,15 @@ struct HouseImageView: View {
     var spacing: CGFloat = 4
     var nameFontSize: Int = 18
 
-    private var imageResource: ImageResource {
+    static func imageResource(for houseId: Int) -> ImageResource {
         switch houseId % 2 {
         case 0: .home
-        default : .home1
+        default: .home1
         }
+    }
+
+    private var imageResource: ImageResource {
+        Self.imageResource(for: houseId)
     }
 
     var body: some View {

--- a/RoomLog/RoomLog/Features/Home/Presentation/Views/HouseListView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Views/HouseListView.swift
@@ -175,7 +175,7 @@ struct HouseListView: View {
     @ViewBuilder
     private func mainHouseCard(house: House) -> some View {
         HStack(spacing: 16) {
-            Image(.home)
+            Image(HouseImageView.imageResource(for: house.houseId))
                 .resizable()
                 .scaledToFit()
                 .frame(height: Layout.mainThumbnailHeight)
@@ -201,7 +201,7 @@ struct HouseListView: View {
     ) -> some View {
         let isCurrent = isEditing && isSelected
         VStack(spacing: Layout.cardGap) {
-            Image(.home)
+            Image(HouseImageView.imageResource(for: house.houseId))
                 .resizable()
                 .scaledToFit()
                 .frame(height: Layout.gridThumbnailHeight)


### PR DESCRIPTION
## ✨ PR 유형
- [x] 새로운 기능 추가

<br>

## 🛠️ 작업 내용
- `HouseImageView`에 `static func imageResource(for:)` 헬퍼 추가
- `HouseListView`의 mainHouseCard, houseGridItem에서 `Image(.home)` → `HouseImageView.imageResource(for:)` 사용으로 변경
- HouseMapView와 동일하게 houseId 기반으로 집 디자인 일관 적용

<br>

## 🔍 관련 이슈
- closed #75

<br>

## 📸 스크린샷 - UI작업인 경우만 추가