### PR TITLE
[Feat] 하자점검 수리내역조회 UI 및 API 연동

### DIFF
--- a/RoomLog/RoomLog/Core/Common/UIComponents/SeverityBadge.swift
+++ b/RoomLog/RoomLog/Core/Common/UIComponents/SeverityBadge.swift
@@ -1,0 +1,74 @@
+//
+//  SeverityBadge.swift
+//  RoomLog
+//
+//  Created by minkyo on 5/17/26.
+//
+
+import SwiftUI
+
+struct SeverityBadge: View {
+    let severity: Severity
+    var size: BadgeSize = .small
+
+    enum BadgeSize {
+        case small, medium
+    }
+
+    var body: some View {
+        Text(severity.label)
+            .font(.system(size: fontSize, weight: .medium))
+            .foregroundStyle(severity.color)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
+            .background(severity.color.opacity(0.2), in: RoundedRectangle(cornerRadius: cornerRadius))
+    }
+
+    private var fontSize: CGFloat {
+        switch size {
+        case .small: 12
+        case .medium: 16
+        }
+    }
+
+    private var horizontalPadding: CGFloat {
+        switch size {
+        case .small: 8
+        case .medium: 12
+        }
+    }
+
+    private var verticalPadding: CGFloat {
+        switch size {
+        case .small: 4
+        case .medium: 6
+        }
+    }
+
+    private var cornerRadius: CGFloat {
+        switch size {
+        case .small: 7
+        case .medium: 12
+        }
+    }
+}
+
+// MARK: - Severity Display
+
+extension Severity {
+    var label: String {
+        switch self {
+        case .high: "높음"
+        case .medium: "보통"
+        case .low: "낮음"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .high: Color(red: 0.89, green: 0.21, blue: 0.22)
+        case .medium: Color(red: 0.94, green: 0.55, blue: 0.12)
+        case .low: Color(red: 0.21, green: 0.38, blue: 0.89)
+        }
+    }
+}

--- a/RoomLog/RoomLog/Core/Common/UIComponents/SystemToastView.swift
+++ b/RoomLog/RoomLog/Core/Common/UIComponents/SystemToastView.swift
@@ -1,0 +1,28 @@
+//
+//  SystemToastView.swift
+//  RoomLog
+//
+//  Created by 송민교 on 5/19/26.
+//
+
+import SwiftUI
+
+struct SystemToastView<Label: View>: View {
+    let systemImage: String
+
+    @ViewBuilder let label: () -> Label
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: systemImage)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Color.mutedBlue)
+            label()
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 12)
+        .background(.blueGray50)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.1), radius: 5, y: 2)
+    }
+}

--- a/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
@@ -26,6 +26,7 @@ enum NavigationDestination: Hashable {
         case defectListMain(roomId: Int)
         case defectListDetail(defect: DefectReportDetail, roomId: Int, roomImageURL: String?)
         case repairShopList(roomId: Int, defect: DefectReportDetail)
+        case repairHistory
     }
     
     enum MyPage: Hashable {

--- a/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
@@ -26,7 +26,7 @@ enum NavigationDestination: Hashable {
         case defectListMain(roomId: Int)
         case defectListDetail(defect: DefectReportDetail, roomId: Int, roomImageURL: String?)
         case repairShopList(roomId: Int, defect: DefectReportDetail)
-        case repairHistory
+        case repairHistory(roomId: Int)
     }
     
     enum MyPage: Hashable {

--- a/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
@@ -79,8 +79,8 @@ private extension NavigationRoutingView {
             DefectDetailView(defect: defect, roomId: roomId, roomImageURL: roomImageURL)
         case .repairShopList(let roomId, let defect):
             RepairShopListView(roomId: roomId, defect: defect, provider: di.resolve(EstimateUseCaseProvider.self))
-        case .repairHistory:
-            RepairHistoryView(provider: di.resolve(EstimateUseCaseProvider.self))
+        case .repairHistory(let roomId):
+            RepairHistoryView(roomId: roomId, provider: di.resolve(EstimateUseCaseProvider.self))
         }
     }
     

--- a/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
@@ -79,6 +79,8 @@ private extension NavigationRoutingView {
             DefectDetailView(defect: defect, roomId: roomId, roomImageURL: roomImageURL)
         case .repairShopList(let roomId, let defect):
             RepairShopListView(roomId: roomId, defect: defect, provider: di.resolve(EstimateUseCaseProvider.self))
+        case .repairHistory:
+            RepairHistoryView(provider: di.resolve(EstimateUseCaseProvider.self))
         }
     }
     

--- a/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectDetailView.swift
+++ b/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectDetailView.swift
@@ -81,7 +81,7 @@ private extension DefectDetailView {
                 Text("심각도")
                     .font(.medium, 16)
                     .foregroundStyle(Color("dustyBlue"))
-                severityBadge
+                SeverityBadge(severity: defect.severity, size: .medium)
             }
             Spacer()
             VStack(alignment: .trailing, spacing: 12) {
@@ -97,15 +97,6 @@ private extension DefectDetailView {
         .padding(.vertical, 30)
         .frame(maxWidth: .infinity)
         .background(cardBackground)
-    }
-
-    var severityBadge: some View {
-        Text(defect.severity.label)
-            .font(.system(size: 16, weight: .medium))
-            .foregroundStyle(defect.severity.badgeTextColor)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background(defect.severity.badgeTextColor.opacity(0.2), in: RoundedRectangle(cornerRadius: 12))
     }
 
     var formattedRepairCost: String {
@@ -187,19 +178,13 @@ private extension DefectDetailView {
 
 private extension DefectDetailView {
     var bottomButton: some View {
-        Button(action: {
+        BottomCTAButton {
             let pathStore = di.resolve(PathStore.self)
             pathStore.defectPath.append(.defect(.repairShopList(roomId: roomId, defect: defect)))
-        }) {
+        } label: {
             Text("추천 업체 보기")
                 .font(.semibold, 17)
-                .foregroundStyle(.white)
-                .frame(maxWidth: .infinity)
-                .frame(height: 56)
-                .background(Color("mutedBlue"), in: Capsule())
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
     }
 }
 
@@ -224,22 +209,3 @@ private extension DefectDetailView {
     }
 }
 
-// MARK: - Severity Style
-
-private extension Severity {
-    var label: String {
-        switch self {
-        case .high: "높음"
-        case .medium: "중간"
-        case .low: "낮음"
-        }
-    }
-
-    var badgeTextColor: Color {
-        switch self {
-        case .high: .red
-        case .medium: .orange
-        case .low: Color("mutedBlue")
-        }
-    }
-}

--- a/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectView.swift
+++ b/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectView.swift
@@ -56,7 +56,7 @@ struct DefectView: View {
     private var bottomButton: some View {
         BottomCTAButton {
             let pathStore = di.resolve(PathStore.self)
-            pathStore.defectPath.append(.defect(.repairHistory))
+            pathStore.defectPath.append(.defect(.repairHistory(roomId: viewModel.roomId)))
         } label: {
             Text("수리 내역 보기")
                 .font(.semibold, 17)

--- a/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectView.swift
+++ b/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectView.swift
@@ -54,16 +54,13 @@ struct DefectView: View {
     }
 
     private var bottomButton: some View {
-        Button(action: {}) {
+        BottomCTAButton {
+            let pathStore = di.resolve(PathStore.self)
+            pathStore.defectPath.append(.defect(.repairHistory))
+        } label: {
             Text("수리 내역 보기")
                 .font(.semibold, 17)
-                .foregroundStyle(.white)
-                .frame(maxWidth: .infinity)
-                .frame(height: 56)
-                .background(Color.mutedBlue, in: Capsule())
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
     }
 }
 
@@ -228,7 +225,7 @@ private struct DefectReportRow: View {
                 Text(defect.type)
                     .font(.semibold, 16)
                     .foregroundStyle(Color.neutral800)
-                severityBadge
+                SeverityBadge(severity: defect.severity)
             }
 
             Text(defect.location)
@@ -244,15 +241,6 @@ private struct DefectReportRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(.white, in: RoundedRectangle(cornerRadius: 12))
         .shadow(color: .black.opacity(0.12), radius: 5, x: 0, y: 2)
-    }
-
-    private var severityBadge: some View {
-        Text(defect.severity.badgeLabel)
-            .font(.medium, 12)
-            .foregroundStyle(defect.severity.badgeColor)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(defect.severity.badgeColor.opacity(0.2), in: RoundedRectangle(cornerRadius: 7))
     }
 
     private func chip(_ text: String) -> some View {
@@ -276,20 +264,3 @@ private struct DefectReportRow: View {
     }
 }
 
-private extension Severity {
-    var badgeLabel: String {
-        switch self {
-        case .high: "높음"
-        case .medium: "보통"
-        case .low: "낮음"
-        }
-    }
-
-    var badgeColor: Color {
-        switch self {
-        case .high: .red
-        case .medium: .orange
-        case .low: Color.mutedBlue
-        }
-    }
-}

--- a/RoomLog/RoomLog/Features/Estimate/Data/DTO/EstimateDTO.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Data/DTO/EstimateDTO.swift
@@ -120,20 +120,25 @@ struct EstimateItemDTO: Codable {
         )
     }
 
-    private static let fractionalFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.timeZone = TimeZone(identifier: "Asia/Seoul")
-        return f
-    }()
-
     private static func parseDate(_ string: String) -> Date? {
-        // 소수점 초가 있으면 fractional formatter, 없으면 공용 extension 활용
-        if string.contains(".") {
-            return fractionalFormatter.date(from: string)
+        guard string.contains(".") else {
+            return Date.fromServerDateTime(string)
         }
-        return Date.fromServerDateTime(string)
+        // 소수점 이하를 3자리로 잘라 표준 SSS 포맷으로 정규화
+        let normalized: String
+        if let dotIndex = string.firstIndex(of: ".") {
+            let fractionalStart = string.index(after: dotIndex)
+            let fractional = string[fractionalStart...]
+            let trimmed = String(fractional.prefix(3)).padding(toLength: 3, withPad: "0", startingAt: 0)
+            normalized = String(string[..<fractionalStart]) + trimmed
+        } else {
+            normalized = string
+        }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        return formatter.date(from: normalized)
     }
 }
 

--- a/RoomLog/RoomLog/Features/Estimate/Data/DTO/EstimateDTO.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Data/DTO/EstimateDTO.swift
@@ -62,7 +62,137 @@ struct RepairShopDTO: Codable {
     }
 }
 
-// MARK: - Estimate
+// MARK: - Estimate List
+
+struct EstimateListResponseDTO: Codable {
+    let estimates: [EstimateItemDTO]
+    let totalCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case estimates
+        case totalCount = "total_count"
+    }
+}
+
+struct EstimateItemDTO: Codable {
+    let estimateId: Int
+    let status: String
+    let displayStatus: String
+    let message: String?
+    let defects: [EstimateDefectDTO]
+    let providerName: String
+    let providerPhone: String?
+    let providerAddress: String?
+    let createdAt: String
+    let repairId: Int?
+    let repairCost: Int?
+    let repairedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case estimateId = "estimate_id"
+        case status
+        case displayStatus = "display_status"
+        case message
+        case defects
+        case providerName = "provider_name"
+        case providerPhone = "provider_phone"
+        case providerAddress = "provider_address"
+        case createdAt = "created_at"
+        case repairId = "repair_id"
+        case repairCost = "repair_cost"
+        case repairedAt = "repaired_at"
+    }
+
+    func toDomain() -> Estimate {
+        Estimate(
+            id: estimateId,
+            status: EstimateStatus(rawString: status),
+            displayStatus: EstimateDisplayStatus(rawString: displayStatus),
+            message: message,
+            defects: defects.map { $0.toDomain() },
+            providerName: providerName,
+            providerPhone: providerPhone,
+            providerAddress: providerAddress,
+            createdAt: Self.parseDate(createdAt),
+            repairId: repairId,
+            repairCost: repairCost,
+            repairedAt: repairedAt.flatMap { Self.parseDate($0) }
+        )
+    }
+
+    private static let fractionalFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "Asia/Seoul")
+        return f
+    }()
+
+    private static func parseDate(_ string: String) -> Date? {
+        // 소수점 초가 있으면 fractional formatter, 없으면 공용 extension 활용
+        if string.contains(".") {
+            return fractionalFormatter.date(from: string)
+        }
+        return Date.fromServerDateTime(string)
+    }
+}
+
+struct EstimateDefectDTO: Codable {
+    let defectId: Int
+    let analysisId: Int?
+    let type: String
+    let location: String
+    let severity: String
+    let area: Int?
+    let estimatedCost: Int?
+    let description: String?
+
+    enum CodingKeys: String, CodingKey {
+        case defectId = "defect_id"
+        case analysisId = "analysis_id"
+        case type, location, severity, area, description
+        case estimatedCost = "estimated_cost"
+    }
+
+    func toDomain() -> EstimateDefect {
+        EstimateDefect(
+            defectId: defectId,
+            analysisId: analysisId,
+            type: type,
+            location: location,
+            severity: Severity(rawString: severity),
+            area: area,
+            estimatedCost: estimatedCost,
+            description: description
+        )
+    }
+}
+
+// MARK: - Complete Repair
+
+struct CompleteRepairResponseDTO: Codable {
+    let status: String
+    let repairId: Int
+    let estimateId: Int
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case repairId = "repair_id"
+        case estimateId = "estimate_id"
+    }
+}
+
+struct CompleteRepairRequestDTO: Encodable {
+    let repairCost: Int
+    let note: String?
+
+    enum CodingKeys: String, CodingKey {
+        case repairCost = "repair_cost"
+        case note
+    }
+}
+
+// MARK: - Create Estimate
 
 struct CreateEstimateRequestDTO: Encodable {
     let message: String

--- a/RoomLog/RoomLog/Features/Estimate/Data/Repositories/EstimateRepository.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Data/Repositories/EstimateRepository.swift
@@ -40,11 +40,27 @@ final class EstimateRepository: EstimateRepositoryProtocol {
         return (shops: result.repairShops.map { $0.toDomain() }, analysisId: result.analysisId)
     }
 
-    // TODO: 서버 연동 시 실제 API 호출로 교체
-    func getEstimates() async throws -> [Estimate] {
-        try await MockEstimateRepository().getEstimates()
+    func getEstimates(roomId: Int) async throws -> [Estimate] {
+        let response = try await adapter.request(EstimateTarget.getEstimates(roomId: roomId))
+        let apiResponse: APIResponse<EstimateListResponseDTO>
+        do {
+            apiResponse = try decoder.decode(APIResponse<EstimateListResponseDTO>.self, from: response.data)
+        } catch {
+            throw RepositoryError.decodingError(detail: error.localizedDescription)
+        }
+        return try apiResponse.unwrap().estimates.map { $0.toDomain() }
     }
-    func completeRepair(estimateId: Int) async throws {}
+    func completeRepair(estimateId: Int, repairCost: Int, note: String?) async throws {
+        let body = CompleteRepairRequestDTO(repairCost: repairCost, note: note)
+        let response = try await adapter.request(EstimateTarget.completeRepair(estimateId: estimateId, request: body))
+        let apiResponse: APIResponse<CompleteRepairResponseDTO>
+        do {
+            apiResponse = try decoder.decode(APIResponse<CompleteRepairResponseDTO>.self, from: response.data)
+        } catch {
+            throw RepositoryError.decodingError(detail: error.localizedDescription)
+        }
+        _ = try apiResponse.unwrap()
+    }
 
     func createEstimate(message: String, roomId: Int, analysisId: Int?, defectIds: [Int], provider: RepairShop) async throws {
         let body = CreateEstimateRequestDTO(

--- a/RoomLog/RoomLog/Features/Estimate/Data/Repositories/EstimateRepository.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Data/Repositories/EstimateRepository.swift
@@ -40,6 +40,12 @@ final class EstimateRepository: EstimateRepositoryProtocol {
         return (shops: result.repairShops.map { $0.toDomain() }, analysisId: result.analysisId)
     }
 
+    // TODO: 서버 연동 시 실제 API 호출로 교체
+    func getEstimates() async throws -> [Estimate] {
+        try await MockEstimateRepository().getEstimates()
+    }
+    func completeRepair(estimateId: Int) async throws {}
+
     func createEstimate(message: String, roomId: Int, analysisId: Int?, defectIds: [Int], provider: RepairShop) async throws {
         let body = CreateEstimateRequestDTO(
             message: message,

--- a/RoomLog/RoomLog/Features/Estimate/Data/Repositories/MockEstimateRepository.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Data/Repositories/MockEstimateRepository.swift
@@ -17,16 +17,15 @@ final class MockEstimateRepository: EstimateRepositoryProtocol {
         (shops: mockShops, analysisId: nil)
     }
 
-    func getEstimates() async throws -> [Estimate] {
-        [
-            Estimate(id: 1, status: .sent, message: "균열 수리 문의", defectType: "벽지 찢어짐", defectSeverity: .high, defectLocation: "거실 벽면 북서부", repairCost: 15000, providerName: "홈케어 닥터스", providerPhone: "010-1234-5678", providerAddress: "서울시 강남구 테헤란로 123", createdAt: Date()),
-            Estimate(id: 2, status: .sent, message: "곰팡이 제거 문의", defectType: "벽지 찢어짐", defectSeverity: .high, defectLocation: "거실 벽면 북서부", repairCost: 15000, providerName: "홈케어 닥터스", providerPhone: "010-2345-6789", providerAddress: "서울시 서초구 반포대로 56", createdAt: Date(timeIntervalSinceNow: -86400 * 7)),
-            Estimate(id: 3, status: .completed, message: "도배 손상 문의", defectType: "벽지 찢어짐", defectSeverity: .medium, defectLocation: "거실 벽면 북서부", repairCost: 15000, providerName: "홈케어 닥터스", providerPhone: "010-3456-7890", providerAddress: "서울시 강남구 신사동 568", createdAt: Date(timeIntervalSinceNow: -86400 * 14)),
-            Estimate(id: 4, status: .completed, message: "균열 수리 문의", defectType: "벽지 찢어짐", defectSeverity: .low, defectLocation: "거실 벽면 북서부", repairCost: 15000, providerName: "홈케어 닥터스", providerPhone: "010-4567-8901", providerAddress: "서울시 서초구 방배로 78", createdAt: Date(timeIntervalSinceNow: -86400 * 30)),
+    func getEstimates(roomId: Int) async throws -> [Estimate] {
+        let mockDefect = EstimateDefect(defectId: 1, analysisId: nil, type: "CRACK", location: "거실 벽", severity: .high, area: 1, estimatedCost: 75000, description: nil)
+        return [
+            Estimate(id: 1, status: .sent, displayStatus: .inProgress, message: "균열 수리 문의", defects: [mockDefect], providerName: "홈케어 닥터스", providerPhone: "010-1234-5678", providerAddress: "서울시 강남구 테헤란로 123", createdAt: Date(), repairId: nil, repairCost: nil, repairedAt: nil),
+            Estimate(id: 2, status: .completed, displayStatus: .completed, message: "도배 손상 문의", defects: [mockDefect], providerName: "홈케어 닥터스", providerPhone: "010-3456-7890", providerAddress: "서울시 강남구 신사동 568", createdAt: Date(timeIntervalSinceNow: -86400 * 14), repairId: 1, repairCost: 80000, repairedAt: nil),
         ]
     }
 
-    func completeRepair(estimateId: Int) async throws {}
+    func completeRepair(estimateId: Int, repairCost: Int, note: String?) async throws {}
 
     func createEstimate(message: String, roomId: Int, analysisId: Int?, defectIds: [Int], provider: RepairShop) async throws {}
 }

--- a/RoomLog/RoomLog/Features/Estimate/Data/Repositories/MockEstimateRepository.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Data/Repositories/MockEstimateRepository.swift
@@ -17,5 +17,16 @@ final class MockEstimateRepository: EstimateRepositoryProtocol {
         (shops: mockShops, analysisId: nil)
     }
 
+    func getEstimates() async throws -> [Estimate] {
+        [
+            Estimate(id: 1, status: .sent, message: "균열 수리 문의", defectType: "벽지 찢어짐", defectSeverity: .high, defectLocation: "거실 벽면 북서부", repairCost: 15000, providerName: "홈케어 닥터스", providerPhone: "010-1234-5678", providerAddress: "서울시 강남구 테헤란로 123", createdAt: Date()),
+            Estimate(id: 2, status: .sent, message: "곰팡이 제거 문의", defectType: "벽지 찢어짐", defectSeverity: .high, defectLocation: "거실 벽면 북서부", repairCost: 15000, providerName: "홈케어 닥터스", providerPhone: "010-2345-6789", providerAddress: "서울시 서초구 반포대로 56", createdAt: Date(timeIntervalSinceNow: -86400 * 7)),
+            Estimate(id: 3, status: .completed, message: "도배 손상 문의", defectType: "벽지 찢어짐", defectSeverity: .medium, defectLocation: "거실 벽면 북서부", repairCost: 15000, providerName: "홈케어 닥터스", providerPhone: "010-3456-7890", providerAddress: "서울시 강남구 신사동 568", createdAt: Date(timeIntervalSinceNow: -86400 * 14)),
+            Estimate(id: 4, status: .completed, message: "균열 수리 문의", defectType: "벽지 찢어짐", defectSeverity: .low, defectLocation: "거실 벽면 북서부", repairCost: 15000, providerName: "홈케어 닥터스", providerPhone: "010-4567-8901", providerAddress: "서울시 서초구 방배로 78", createdAt: Date(timeIntervalSinceNow: -86400 * 30)),
+        ]
+    }
+
+    func completeRepair(estimateId: Int) async throws {}
+
     func createEstimate(message: String, roomId: Int, analysisId: Int?, defectIds: [Int], provider: RepairShop) async throws {}
 }

--- a/RoomLog/RoomLog/Features/Estimate/Data/Target/EstimateTarget.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Data/Target/EstimateTarget.swift
@@ -13,6 +13,8 @@ enum EstimateTarget {
     case getRepairShops(analysisId: Int, type: String?, radius: String?, sort: String?)
     case getRepairShopsByRoom(roomId: Int, type: String?, radius: String?, sort: String?)
     case createEstimate(request: CreateEstimateRequestDTO)
+    case getEstimates(roomId: Int)
+    case completeRepair(estimateId: Int, request: CompleteRepairRequestDTO)
 }
 
 extension EstimateTarget: BaseTargetType {
@@ -22,16 +24,18 @@ extension EstimateTarget: BaseTargetType {
             return "/analyses/\(analysisId)/repair-shops"
         case .getRepairShopsByRoom(let roomId, _, _, _):
             return "/rooms/\(roomId)/repair-shops"
-        case .createEstimate:
+        case .createEstimate, .getEstimates:
             return "/estimates"
+        case .completeRepair(let estimateId, _):
+            return "/estimates/\(estimateId)/repairs"
         }
     }
 
     var method: Moya.Method {
         switch self {
-        case .getRepairShops, .getRepairShopsByRoom:
+        case .getRepairShops, .getRepairShopsByRoom, .getEstimates:
             return .get
-        case .createEstimate:
+        case .createEstimate, .completeRepair:
             return .post
         }
     }
@@ -46,6 +50,10 @@ extension EstimateTarget: BaseTargetType {
             if let sort { params["sort"] = sort }
             return params.isEmpty ? .requestPlain : .requestParameters(parameters: params, encoding: URLEncoding.queryString)
         case .createEstimate(let request):
+            return .requestJSONEncodable(request)
+        case .getEstimates(let roomId):
+            return .requestParameters(parameters: ["roomId": roomId], encoding: URLEncoding.queryString)
+        case .completeRepair(_, let request):
             return .requestJSONEncodable(request)
         }
     }

--- a/RoomLog/RoomLog/Features/Estimate/Domain/Interfaces/EstimateRepositoryProtocol.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Domain/Interfaces/EstimateRepositoryProtocol.swift
@@ -8,7 +8,15 @@
 import Foundation
 
 protocol EstimateRepositoryProtocol {
+    /// 수리 업체 리스트 조회
     func getRepairShops(analysisId: Int, type: String?, radius: String?, sort: String?) async throws -> [RepairShop]
     func getRepairShopsByRoom(roomId: Int, type: String?, radius: String?, sort: String?) async throws -> (shops: [RepairShop], analysisId: Int?)
+    
+    /// 견적 요청
     func createEstimate(message: String, roomId: Int, analysisId: Int?, defectIds: [Int], provider: RepairShop) async throws
+    
+    /// 견적 요청 목록 조회
+    func getEstimates() async throws -> [Estimate]
+    
+    func completeRepair(estimateId: Int) async throws
 }

--- a/RoomLog/RoomLog/Features/Estimate/Domain/Interfaces/EstimateRepositoryProtocol.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Domain/Interfaces/EstimateRepositoryProtocol.swift
@@ -16,7 +16,7 @@ protocol EstimateRepositoryProtocol {
     func createEstimate(message: String, roomId: Int, analysisId: Int?, defectIds: [Int], provider: RepairShop) async throws
     
     /// 견적 요청 목록 조회
-    func getEstimates() async throws -> [Estimate]
+    func getEstimates(roomId: Int) async throws -> [Estimate]
     
-    func completeRepair(estimateId: Int) async throws
+    func completeRepair(estimateId: Int, repairCost: Int, note: String?) async throws
 }

--- a/RoomLog/RoomLog/Features/Estimate/Domain/Models/Estimate.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Domain/Models/Estimate.swift
@@ -10,15 +10,41 @@ import Foundation
 struct Estimate: Identifiable, Hashable {
     let id: Int
     let status: EstimateStatus
+    let displayStatus: EstimateDisplayStatus
     let message: String?
-    let defectType: String
-    let defectSeverity: Severity
-    let defectLocation: String
-    let repairCost: Int
+    let defects: [EstimateDefect]
     let providerName: String
     let providerPhone: String?
     let providerAddress: String?
     let createdAt: Date?
+    let repairId: Int?
+    let repairCost: Int?
+    let repairedAt: Date?
+}
+
+struct EstimateDefect: Identifiable, Hashable {
+    let defectId: Int
+    let analysisId: Int?
+    let type: String
+    let location: String
+    let severity: Severity
+    let area: Int?
+    let estimatedCost: Int?
+    let description: String?
+
+    var id: Int { defectId }
+
+    var localizedType: String {
+        switch type.uppercased() {
+        case "CRACK": return "균열"
+        case "MOLD": return "곰팡이"
+        case "LEAK": return "누수"
+        case "PEELING": return "박리"
+        case "STAIN": return "얼룩"
+        case "DAMAGE": return "파손"
+        default: return type
+        }
+    }
 }
 
 enum EstimateStatus: Hashable {
@@ -37,8 +63,26 @@ enum EstimateStatus: Hashable {
     var label: String {
         switch self {
         case .requested: "대기중"
-        case .sent: "진행중"
+        case .sent: "발송됨"
         case .failed: "실패"
+        case .completed: "완료"
+        }
+    }
+}
+
+enum EstimateDisplayStatus: Hashable {
+    case inProgress, completed
+
+    init(rawString: String) {
+        switch rawString.uppercased() {
+        case "COMPLETED": self = .completed
+        default: self = .inProgress
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .inProgress: "진행중"
         case .completed: "완료"
         }
     }

--- a/RoomLog/RoomLog/Features/Estimate/Domain/Models/Estimate.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Domain/Models/Estimate.swift
@@ -1,0 +1,45 @@
+//
+//  Estimate.swift
+//  RoomLog
+//
+//  Created by 송민교 on 5/17/26.
+//
+
+import Foundation
+
+struct Estimate: Identifiable, Hashable {
+    let id: Int
+    let status: EstimateStatus
+    let message: String?
+    let defectType: String
+    let defectSeverity: Severity
+    let defectLocation: String
+    let repairCost: Int
+    let providerName: String
+    let providerPhone: String?
+    let providerAddress: String?
+    let createdAt: Date?
+}
+
+enum EstimateStatus: Hashable {
+    case requested, sent, failed, completed
+
+    init(rawString: String) {
+        switch rawString.uppercased() {
+        case "REQUESTED": self = .requested
+        case "SENT": self = .sent
+        case "FAILED": self = .failed
+        case "COMPLETED": self = .completed
+        default: self = .requested
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .requested: "대기중"
+        case .sent: "진행중"
+        case .failed: "실패"
+        case .completed: "완료"
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/CompleteRepairUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/CompleteRepairUseCaseProtocol.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol CompleteRepairUseCaseProtocol {
-    func execute(estimateId: Int) async throws
+    func execute(estimateId: Int, repairCost: Int, note: String?) async throws
 }

--- a/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/CompleteRepairUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/CompleteRepairUseCaseProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  CompleteRepairUseCaseProtocol.swift
+//  RoomLog
+//
+//  Created by 송민교 on 5/17/26.
+//
+
+import Foundation
+
+protocol CompleteRepairUseCaseProtocol {
+    func execute(estimateId: Int) async throws
+}

--- a/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/GetEstimatesUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/GetEstimatesUseCaseProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  GetEstimatesUseCaseProtocol.swift
+//  RoomLog
+//
+//  Created by 송민교 on 5/17/26.
+//
+
+import Foundation
+
+protocol GetEstimatesUseCaseProtocol {
+    func execute() async throws -> [Estimate]
+}

--- a/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/GetEstimatesUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/GetEstimatesUseCaseProtocol.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol GetEstimatesUseCaseProtocol {
-    func execute() async throws -> [Estimate]
+    func execute(roomId: Int) async throws -> [Estimate]
 }

--- a/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/Implementations/CompleteRepairUseCase.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/Implementations/CompleteRepairUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  CompleteRepairUseCase.swift
+//  RoomLog
+//
+//  Created by 송민교 on 5/17/26.
+//
+
+import Foundation
+
+final class CompleteRepairUseCase: CompleteRepairUseCaseProtocol {
+    private let repository: EstimateRepositoryProtocol
+
+    init(repository: EstimateRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(estimateId: Int) async throws {
+        try await repository.completeRepair(estimateId: estimateId)
+    }
+}

--- a/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/Implementations/CompleteRepairUseCase.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/Implementations/CompleteRepairUseCase.swift
@@ -14,7 +14,7 @@ final class CompleteRepairUseCase: CompleteRepairUseCaseProtocol {
         self.repository = repository
     }
 
-    func execute(estimateId: Int) async throws {
-        try await repository.completeRepair(estimateId: estimateId)
+    func execute(estimateId: Int, repairCost: Int, note: String?) async throws {
+        try await repository.completeRepair(estimateId: estimateId, repairCost: repairCost, note: note)
     }
 }

--- a/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/Implementations/GetEstimatesUseCase.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/Implementations/GetEstimatesUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  GetEstimatesUseCase.swift
+//  RoomLog
+//
+//  Created by 송민교 on 5/17/26.
+//
+
+import Foundation
+
+final class GetEstimatesUseCase: GetEstimatesUseCaseProtocol {
+    private let repository: EstimateRepositoryProtocol
+
+    init(repository: EstimateRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute() async throws -> [Estimate] {
+        try await repository.getEstimates()
+    }
+}

--- a/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/Implementations/GetEstimatesUseCase.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Domain/UseCases/Implementations/GetEstimatesUseCase.swift
@@ -14,7 +14,7 @@ final class GetEstimatesUseCase: GetEstimatesUseCaseProtocol {
         self.repository = repository
     }
 
-    func execute() async throws -> [Estimate] {
-        try await repository.getEstimates()
+    func execute(roomId: Int) async throws -> [Estimate] {
+        try await repository.getEstimates(roomId: roomId)
     }
 }

--- a/RoomLog/RoomLog/Features/Estimate/Presentation/Provider/EstimateUseCaseProvider.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Presentation/Provider/EstimateUseCaseProvider.swift
@@ -11,6 +11,8 @@ protocol EstimateUseCaseProvider {
     func makeGetRepairShopsUseCase() -> GetRepairShopsUseCaseProtocol
     func makeGetRepairShopsByRoomUseCase() -> GetRepairShopsByRoomUseCaseProtocol
     func makeCreateEstimateUseCase() -> CreateEstimateUseCaseProtocol
+    func makeGetEstimatesUseCase() -> GetEstimatesUseCaseProtocol
+    func makeCompleteRepairUseCase() -> CompleteRepairUseCaseProtocol
 }
 
 final class EstimateUseCaseProviderImpl: EstimateUseCaseProvider {
@@ -18,6 +20,10 @@ final class EstimateUseCaseProviderImpl: EstimateUseCaseProvider {
 
     init(adapter: MoyaNetworkAdapter) {
         self.repository = EstimateRepository(adapter: adapter)
+    }
+
+    init(repository: EstimateRepositoryProtocol) {
+        self.repository = repository
     }
 
     func makeGetRepairShopsUseCase() -> GetRepairShopsUseCaseProtocol {
@@ -30,5 +36,13 @@ final class EstimateUseCaseProviderImpl: EstimateUseCaseProvider {
 
     func makeCreateEstimateUseCase() -> CreateEstimateUseCaseProtocol {
         CreateEstimateUseCase(repository: repository)
+    }
+
+    func makeGetEstimatesUseCase() -> GetEstimatesUseCaseProtocol {
+        GetEstimatesUseCase(repository: repository)
+    }
+
+    func makeCompleteRepairUseCase() -> CompleteRepairUseCaseProtocol {
+        CompleteRepairUseCase(repository: repository)
     }
 }

--- a/RoomLog/RoomLog/Features/Estimate/Presentation/ViewModels/RepairHistoryViewModel.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Presentation/ViewModels/RepairHistoryViewModel.swift
@@ -7,17 +7,21 @@
 
 import Foundation
 
+@MainActor
 @Observable
 final class RepairHistoryViewModel {
     // MARK: - State
     private(set) var estimates: [Estimate] = []
     private(set) var isLoading = false
     var errorMessage: String?
+    var showSuccessToast = false
 
     // MARK: - Provider
     private let provider: EstimateUseCaseProvider
+    private let roomId: Int
 
-    init(provider: EstimateUseCaseProvider) {
+    init(roomId: Int, provider: EstimateUseCaseProvider) {
+        self.roomId = roomId
         self.provider = provider
     }
 
@@ -26,7 +30,17 @@ final class RepairHistoryViewModel {
         isLoading = true
         defer { isLoading = false }
         do {
-            estimates = try await provider.makeGetEstimatesUseCase().execute()
+            estimates = try await provider.makeGetEstimatesUseCase().execute(roomId: roomId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func completeRepair(estimateId: Int, repairCost: Int, note: String?) async {
+        do {
+            try await provider.makeCompleteRepairUseCase().execute(estimateId: estimateId, repairCost: repairCost, note: note)
+            estimates = try await provider.makeGetEstimatesUseCase().execute(roomId: roomId)
+            showSuccessToast = true
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/RoomLog/RoomLog/Features/Estimate/Presentation/ViewModels/RepairHistoryViewModel.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Presentation/ViewModels/RepairHistoryViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  RepairHistoryViewModel.swift
+//  RoomLog
+//
+//  Created by minkyo on 5/17/26.
+//
+
+import Foundation
+
+@Observable
+final class RepairHistoryViewModel {
+    // MARK: - State
+    private(set) var estimates: [Estimate] = []
+    private(set) var isLoading = false
+    var errorMessage: String?
+
+    // MARK: - Provider
+    private let provider: EstimateUseCaseProvider
+
+    init(provider: EstimateUseCaseProvider) {
+        self.provider = provider
+    }
+
+    // MARK: - Actions
+    func fetchEstimates() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            estimates = try await provider.makeGetEstimatesUseCase().execute()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Estimate/Presentation/ViewModels/RepairHistoryViewModel.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Presentation/ViewModels/RepairHistoryViewModel.swift
@@ -39,8 +39,13 @@ final class RepairHistoryViewModel {
     func completeRepair(estimateId: Int, repairCost: Int, note: String?) async {
         do {
             try await provider.makeCompleteRepairUseCase().execute(estimateId: estimateId, repairCost: repairCost, note: note)
-            estimates = try await provider.makeGetEstimatesUseCase().execute(roomId: roomId)
             showSuccessToast = true
+        } catch {
+            errorMessage = error.localizedDescription
+            return
+        }
+        do {
+            estimates = try await provider.makeGetEstimatesUseCase().execute(roomId: roomId)
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/RoomLog/RoomLog/Features/Estimate/Presentation/Views/RepairHistoryView.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Presentation/Views/RepairHistoryView.swift
@@ -1,0 +1,179 @@
+//
+//  RepairHistoryView.swift
+//  RoomLog
+//
+//  Created by minkyo on 5/17/26.
+//
+
+import SwiftUI
+
+struct RepairHistoryView: View {
+    @Environment(\.di) var di
+    @State private var viewModel: RepairHistoryViewModel
+
+    init(provider: EstimateUseCaseProvider) {
+        self._viewModel = .init(
+            wrappedValue: RepairHistoryViewModel(provider: provider)
+        )
+    }
+
+    var body: some View {
+        Group {
+            if let report = viewModel.estimates.first {
+                content
+            } else if viewModel.isLoading {
+                ProgressView()
+            } else {
+                emptyView
+            }
+        }
+        .navigationTitle("수리내역")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await viewModel.fetchEstimates()
+        }
+        .alert("오류", isPresented: Binding(
+            get: { viewModel.errorMessage != nil },
+            set: { if !$0 { viewModel.errorMessage = nil } }
+        )) {
+            Button("확인", role: .cancel) {}
+        } message: {
+            Text(viewModel.errorMessage ?? "")
+        }
+    }
+
+    private var content: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                ForEach(viewModel.estimates) { estimate in
+                    RepairHistoryCard(estimate: estimate)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: 12) {
+            Text("수리 내역이 없습니다")
+                .font(.medium, 16)
+                .foregroundStyle(Color.blueGray500)
+        }
+    }
+}
+
+// MARK: - Repair History Card
+
+private struct RepairHistoryCard: View {
+    let estimate: Estimate
+
+    var body: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 20) {
+                defectInfo
+                dateAndShopInfo
+            }
+            Spacer()
+            statusBadge
+        }
+        .padding(16)
+        .background(.white, in: RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.12), radius: 5, x: 0, y: 2)
+    }
+
+    // MARK: - 하자 타입 + 심각도 + 위치
+
+    private var defectInfo: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Text(estimate.defectType)
+                    .font(.semibold, 16)
+                    .foregroundStyle(Color.neutral800)
+                SeverityBadge(severity: estimate.defectSeverity)
+            }
+            Text(estimate.defectLocation)
+                .font(.medium, 14)
+                .foregroundStyle(Color.neutral400)
+        }
+    }
+
+    // MARK: - 날짜 + 가격 + 업체
+    private var dateAndShopInfo: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 4) {
+                Image(systemName: "calendar")
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color.blueGray500)
+                Text(formattedDate)
+                    .font(.medium, 14)
+                    .foregroundStyle(Color.blueGray600)
+            }
+            HStack(spacing: 16) {
+                Text(formattedCost)
+                    .font(.semibold, 14)
+                    .foregroundStyle(Color.neutral700)
+                Divider()
+                    .frame(height: 16)
+                Text(estimate.providerName)
+                    .font(.medium, 14)
+                    .foregroundStyle(Color.neutral700)
+            }
+        }
+    }
+
+    // MARK: - 상태 뱃지
+    private var statusBadge: some View {
+        Text(estimate.status.label)
+            .font(.system(size: 16, weight: .medium))
+            .foregroundStyle(statusForeground)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(statusBackground, in: RoundedRectangle(cornerRadius: 16))
+    }
+
+    private var statusForeground: Color {
+        switch estimate.status {
+        case .sent, .requested:
+            .white
+        case .completed, .failed:
+            Color.mutedBlue
+        }
+    }
+
+    private var statusBackground: Color {
+        switch estimate.status {
+        case .sent, .requested:
+            Color.mutedBlue
+        case .completed, .failed:
+            Color.blueGray50
+        }
+    }
+
+    // MARK: - Formatting
+
+    private var formattedDate: String {
+        guard let date = estimate.createdAt else { return "" }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.MM.dd"
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter.string(from: date)
+    }
+
+    private var formattedCost: String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        let s = formatter.string(from: NSNumber(value: estimate.repairCost)) ?? "\(estimate.repairCost)"
+        return "₩ \(s)"
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    let di = DIContainer.configured()
+    NavigationStack {
+        RepairHistoryView(provider: di.resolve(EstimateUseCaseProvider.self))
+    }
+    .environment(\.di, di)
+}

--- a/RoomLog/RoomLog/Features/Estimate/Presentation/Views/RepairHistoryView.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Presentation/Views/RepairHistoryView.swift
@@ -2,7 +2,7 @@
 //  RepairHistoryView.swift
 //  RoomLog
 //
-//  Created by minkyo on 5/17/26.
+//  Created by 송민교 on 5/17/26.
 //
 
 import SwiftUI
@@ -10,21 +10,22 @@ import SwiftUI
 struct RepairHistoryView: View {
     @Environment(\.di) var di
     @State private var viewModel: RepairHistoryViewModel
+    @State private var selectedEstimate: Estimate?
 
-    init(provider: EstimateUseCaseProvider) {
+    init(roomId: Int, provider: EstimateUseCaseProvider) {
         self._viewModel = .init(
-            wrappedValue: RepairHistoryViewModel(provider: provider)
+            wrappedValue: RepairHistoryViewModel(roomId: roomId, provider: provider)
         )
     }
 
     var body: some View {
         Group {
-            if let report = viewModel.estimates.first {
-                content
+            if viewModel.estimates.isEmpty && !viewModel.isLoading {
+                emptyView
             } else if viewModel.isLoading {
                 ProgressView()
             } else {
-                emptyView
+                content
             }
         }
         .navigationTitle("수리내역")
@@ -40,6 +41,28 @@ struct RepairHistoryView: View {
         } message: {
             Text(viewModel.errorMessage ?? "")
         }
+        .sheet(item: $selectedEstimate) { estimate in
+            EstimateDetailSheet(estimate: estimate) { repairCost, note in
+                await viewModel.completeRepair(estimateId: estimate.id, repairCost: repairCost, note: note)
+                selectedEstimate = nil
+            }
+        }
+        .overlay(alignment: .top) {
+            if viewModel.showSuccessToast {
+                SystemToastView(systemImage: "checkmark.circle.fill") {
+                    Text("수리 완료가 등록되었습니다.")
+                        .font(.medium, 14)
+                        .foregroundStyle(Color.neutral600)
+                }
+                .padding(.top, 8)
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .onAppear {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                        withAnimation { viewModel.showSuccessToast = false }
+                    }
+                }
+            }
+        }
     }
 
     private var content: some View {
@@ -47,6 +70,9 @@ struct RepairHistoryView: View {
             LazyVStack(spacing: 12) {
                 ForEach(viewModel.estimates) { estimate in
                     RepairHistoryCard(estimate: estimate)
+                        .onTapGesture {
+                            selectedEstimate = estimate
+                        }
                 }
             }
             .padding(.horizontal, 16)
@@ -60,6 +86,95 @@ struct RepairHistoryView: View {
                 .font(.medium, 16)
                 .foregroundStyle(Color.blueGray500)
         }
+    }
+}
+
+// MARK: - Estimate Detail Sheet
+
+private struct EstimateDetailSheet: View {
+    let estimate: Estimate
+    let onComplete: (Int, String?) async -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var repairCostText = ""
+    @State private var note = ""
+    @State private var isCompleting = false
+    @State private var showPriceError = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            Text("문의 내용")
+                .font(.semibold, 18)
+                .foregroundStyle(Color.neutral800)
+
+            ScrollView {
+                Text(estimate.message ?? "문자 전송 내역이 없습니다.")
+                    .font(.regular, 15)
+                    .foregroundStyle(Color.neutral600)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(16)
+            }
+            .frame(maxHeight: 160)
+            .background(Color.blueGray50, in: RoundedRectangle(cornerRadius: 12))
+
+            if estimate.displayStatus == .inProgress {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("수리 비용 (원)")
+                        .font(.medium, 14)
+                        .foregroundStyle(Color.neutral600)
+                    TextField("수리 비용을 입력하세요", text: $repairCostText)
+                        .keyboardType(.numberPad)
+                        .padding(12)
+                        .background(Color.blueGray50, in: RoundedRectangle(cornerRadius: 10))
+                    if showPriceError {
+                        Text("수리 비용을 입력해주세요.")
+                            .font(.regular, 13)
+                            .foregroundStyle(Color.red)
+                    }
+
+                    Text("메모")
+                        .font(.medium, 14)
+                        .foregroundStyle(Color.neutral600)
+                    TextField("메모를 입력하세요 (선택)", text: $note)
+                        .padding(12)
+                        .background(Color.blueGray50, in: RoundedRectangle(cornerRadius: 10))
+                }
+            }
+
+            Spacer()
+
+            if estimate.displayStatus == .inProgress {
+                Button {
+                    guard let cost = Int(repairCostText), cost > 0 else {
+                        showPriceError = true
+                        return
+                    }
+                    showPriceError = false
+                    isCompleting = true
+                    Task {
+                        await onComplete(cost, note.isEmpty ? nil : note)
+                        isCompleting = false
+                        dismiss()
+                    }
+                } label: {
+                    Group {
+                        if isCompleting {
+                            ProgressView().tint(.white)
+                        } else {
+                            Text("수리 완료")
+                                .font(.semibold, 17)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 52)
+                    .background(Color.mutedBlue, in: RoundedRectangle(cornerRadius: 12))
+                    .foregroundStyle(.white)
+                }
+                .disabled(isCompleting)
+            }
+        }
+        .padding(24)
+        .presentationDetents([.medium, .large])
     }
 }
 
@@ -86,19 +201,22 @@ private struct RepairHistoryCard: View {
 
     private var defectInfo: some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 10) {
-                Text(estimate.defectType)
-                    .font(.semibold, 16)
-                    .foregroundStyle(Color.neutral800)
-                SeverityBadge(severity: estimate.defectSeverity)
+            ForEach(estimate.defects) { defect in
+                HStack(spacing: 10) {
+                    Text(defect.localizedType)
+                        .font(.semibold, 16)
+                        .foregroundStyle(Color.neutral800)
+                    SeverityBadge(severity: defect.severity)
+                }
+                Text(defect.location)
+                    .font(.medium, 14)
+                    .foregroundStyle(Color.neutral400)
             }
-            Text(estimate.defectLocation)
-                .font(.medium, 14)
-                .foregroundStyle(Color.neutral400)
         }
     }
 
     // MARK: - 날짜 + 가격 + 업체
+
     private var dateAndShopInfo: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 4) {
@@ -110,21 +228,31 @@ private struct RepairHistoryCard: View {
                     .foregroundStyle(Color.blueGray600)
             }
             HStack(spacing: 16) {
-                Text(formattedCost)
-                    .font(.semibold, 14)
-                    .foregroundStyle(Color.neutral700)
-                Divider()
-                    .frame(height: 16)
+                if let cost = estimate.repairCost {
+                    Text(formattedCost(cost))
+                        .font(.semibold, 14)
+                        .foregroundStyle(Color.neutral700)
+                    Divider()
+                        .frame(height: 16)
+                } else if let estimatedCost = estimate.defects.first?.estimatedCost {
+                    Text("예상 " + formattedCost(estimatedCost))
+                        .font(.semibold, 14)
+                        .foregroundStyle(Color.neutral500)
+                    Divider()
+                        .frame(height: 16)
+                }
                 Text(estimate.providerName)
                     .font(.medium, 14)
                     .foregroundStyle(Color.neutral700)
+                    .lineLimit(1)
             }
         }
     }
 
     // MARK: - 상태 뱃지
+
     private var statusBadge: some View {
-        Text(estimate.status.label)
+        Text(estimate.displayStatus.label)
             .font(.system(size: 16, weight: .medium))
             .foregroundStyle(statusForeground)
             .padding(.horizontal, 12)
@@ -133,37 +261,29 @@ private struct RepairHistoryCard: View {
     }
 
     private var statusForeground: Color {
-        switch estimate.status {
-        case .sent, .requested:
-            .white
-        case .completed, .failed:
-            Color.mutedBlue
+        switch estimate.displayStatus {
+        case .inProgress: .white
+        case .completed: Color.mutedBlue
         }
     }
 
     private var statusBackground: Color {
-        switch estimate.status {
-        case .sent, .requested:
-            Color.mutedBlue
-        case .completed, .failed:
-            Color.blueGray50
+        switch estimate.displayStatus {
+        case .inProgress: Color.mutedBlue
+        case .completed: Color.blueGray50
         }
     }
 
     // MARK: - Formatting
 
     private var formattedDate: String {
-        guard let date = estimate.createdAt else { return "" }
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy.MM.dd"
-        formatter.locale = Locale(identifier: "ko_KR")
-        return formatter.string(from: date)
+        estimate.createdAt?.toShortDisplayString() ?? ""
     }
 
-    private var formattedCost: String {
+    private func formattedCost(_ value: Int) -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        let s = formatter.string(from: NSNumber(value: estimate.repairCost)) ?? "\(estimate.repairCost)"
+        let s = formatter.string(from: NSNumber(value: value)) ?? "\(value)"
         return "₩ \(s)"
     }
 }
@@ -173,7 +293,7 @@ private struct RepairHistoryCard: View {
 #Preview {
     let di = DIContainer.configured()
     NavigationStack {
-        RepairHistoryView(provider: di.resolve(EstimateUseCaseProvider.self))
+        RepairHistoryView(roomId: 1, provider: di.resolve(EstimateUseCaseProvider.self))
     }
     .environment(\.di, di)
 }


### PR DESCRIPTION
## ✨ PR 유형
- [ ] <!-- 변경 사항 작성 -->견적 목록 조회 및 수리 완료 등록 기능

<br>

## 🛠️ 작업 내용
- <!-- 작업 내용 작성 --> 수리내역 카드 리스트 UI
- DefectView → "수리 내역 보기" 네비게이션 연결  

리팩토링
- SeverityBadge 공통 컴포넌트
- Defect 하단 버튼 BottomCTAButton 공통 컴포넌트 적용   

<br>

## 🔍 관련 이슈
- closed #65 

수리 완료 후 수리 목록 재조회시 서버 내부 오류(500)발생. 재조회 이슈 관련 추후 확인 예정

<br>

## 📸 스크린샷 - UI작업인 경우만 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 수리 내역 화면 추가: 과거 견적/수리 내역 조회, 상세 보기 및 수리 완료 처리 가능
  * 견적 가져오기 및 수리 완료 기능(서버 연동) 추가

* **UI/UX 개선**
  * 심각도 배지 신규 컴포넌트 도입으로 일관된 심각도 표기 제공
  * 하단 CTA 및 버튼 스타일 통합으로 인터페이스 일관성 향상
* **네비게이션**
  * 수리 내역으로 이동하는 경로 추가 및 연동 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DGU-Team404/roomlog-ios/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->