### PR TITLE
[Refactor] 스캔 업로드 시 scan_type 파라미터 제거

### DIFF
--- a/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
@@ -15,7 +15,7 @@ enum NavigationDestination: Hashable {
     enum Home: Hashable {
         case roomList(houseId: Int, houseName: String)
         case roomDetail(roomId: Int)
-        case scan(houseId: Int, scanType: String)
+        case scan(houseId: Int)
         case plyPreview(fileURL: URL, scanId: Int, houseId: Int)
         case houseList
     }

--- a/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
@@ -49,11 +49,10 @@ private extension NavigationRoutingView {
                 provider: provider,
                 scanRepository: di.resolve(ScanRepositoryProtocol.self)
             )
-        case .scan(let houseId, let scanType):
+        case .scan(let houseId):
             let pathStore = di.resolve(PathStore.self)
             ScanView(
                 houseId: houseId,
-                scanType: scanType,
                 processingManager: di.resolve(ScanProcessingManager.self),
                 onStartConversion: {
                     _ = pathStore.homePath.popLast()

--- a/RoomLog/RoomLog/Features/Home/Presentation/Views/RoomListView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Views/RoomListView.swift
@@ -34,7 +34,6 @@ struct RoomListView: View {
     @Environment(\.di) private var di
     @State private var viewModel: RoomListViewModel
     @State private var showProcessingStatus: Bool = false
-    @State private var showScanTypeSheet: Bool = false
 
     init(houseId: Int, houseName: String, provider: HomeUseCaseProvider) {
         self._viewModel = .init(
@@ -251,28 +250,13 @@ struct RoomListView: View {
             }
         } else {
             BottomCTAButton {
-                showScanTypeSheet = true
+                pathStore.homePath.append(.home(.scan(houseId: viewModel.houseId)))
             } label: {
                 HStack(spacing: 8) {
                     Image(.scan)
                     Text(Strings.scanButton)
                         .font(.semibold, 16)
                 }
-            }
-            .confirmationDialog("스캔 유형을 선택하세요", isPresented: $showScanTypeSheet, titleVisibility: .visible) {
-                Button {
-                    pathStore.homePath.append(.home(.scan(houseId: viewModel.houseId, scanType: "IN")))
-                } label: {
-                    Text("입주 전 스캔")
-                        .font(.medium, 16)
-                }
-                Button {
-                    pathStore.homePath.append(.home(.scan(houseId: viewModel.houseId, scanType: "OUT")))
-                } label: {
-                    Text("퇴거 전 스캔")
-                        .font(.medium, 16)
-                }
-                Button("취소", role: .cancel) {}
             }
         }
     }

--- a/RoomLog/RoomLog/Features/Scan/Data/DTO/ScanResultResponseDTO.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/DTO/ScanResultResponseDTO.swift
@@ -11,14 +11,12 @@ struct ScanResultResponseDTO: Codable {
     let status: String
     let scanId: Int
     let fileURL: String
-    let scanType: String
     let createdAt: String
 
     enum CodingKeys: String, CodingKey {
         case status
         case scanId = "scan_id"
         case fileURL = "file_url"
-        case scanType = "scan_type"
         case createdAt = "created_at"
     }
 
@@ -27,7 +25,7 @@ struct ScanResultResponseDTO: Codable {
             scanId: scanId,
             status: status,
             fileURL: fileURL,
-            scanType: scanType
+            scanType: ""
         )
     }
 }

--- a/RoomLog/RoomLog/Features/Scan/Data/Repositories/ScanRepository.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Repositories/ScanRepository.swift
@@ -20,9 +20,9 @@ final class ScanRepository: ScanRepositoryProtocol {
     }
 
     // MARK: - Function
-    func uploadScan(houseId: Int, scanType: String, fileURL: URL) async throws -> ScanResult {
+    func uploadScan(houseId: Int, fileURL: URL) async throws -> ScanResult {
         let response = try await adapter.request(
-            ScanTarget.uploadScan(houseId: houseId, scanType: scanType, fileURL: fileURL)
+            ScanTarget.uploadScan(houseId: houseId, fileURL: fileURL)
         )
         do {
             let dto = try decoder.decode(APIResponse<ScanResultResponseDTO>.self, from: response.data)

--- a/RoomLog/RoomLog/Features/Scan/Data/Target/ScanTarget.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Target/ScanTarget.swift
@@ -10,7 +10,7 @@ import Moya
 internal import Alamofire
 
 enum ScanTarget {
-    case uploadScan(houseId: Int, scanType: String, fileURL: URL)
+    case uploadScan(houseId: Int, fileURL: URL)
     case getScanStatus(scanId: Int)
     case getScanPreview(scanId: Int)
 }
@@ -38,7 +38,7 @@ extension ScanTarget: BaseTargetType {
 
     var task: Moya.Task {
         switch self {
-        case .uploadScan(let houseId, let scanType, let fileURL):
+        case .uploadScan(let houseId, let fileURL):
             let formData = MultipartFormData(
                 provider: .file(fileURL),
                 name: "file",
@@ -47,7 +47,7 @@ extension ScanTarget: BaseTargetType {
             )
             return .uploadCompositeMultipart(
                 [formData],
-                urlParameters: ["house_id": houseId, "scan_type": scanType]
+                urlParameters: ["house_id": houseId]
             )
         case .getScanStatus, .getScanPreview:
             return .requestPlain

--- a/RoomLog/RoomLog/Features/Scan/Domain/Interfaces/ScanRepositoryProtocol.swift
+++ b/RoomLog/RoomLog/Features/Scan/Domain/Interfaces/ScanRepositoryProtocol.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol ScanRepositoryProtocol {
-    func uploadScan(houseId: Int, scanType: String, fileURL: URL) async throws -> ScanResult
+    func uploadScan(houseId: Int, fileURL: URL) async throws -> ScanResult
     func getScanStatus(scanId: Int) async throws -> String
     func getScanPreview(scanId: Int) async throws -> String
 }

--- a/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
@@ -55,11 +55,11 @@ final class ScanProcessingManager {
 
     /// 촬영 완료 후 호출. wrapUp → 압축 → 업로드 → 폴링 → 다운로드 전체 수행.
     @MainActor
-    func startFullProcess(encoder: DatasetEncoder, houseId: Int, scanType: String) {
+    func startFullProcess(encoder: DatasetEncoder, houseId: Int) {
         processingTask?.cancel()
         activeScan = ActiveScan(scanId: 0, houseId: houseId, phase: .zipping)
         processingTask = Task { [weak self] in
-            await self?.fullProcess(encoder: encoder, houseId: houseId, scanType: scanType)
+            await self?.fullProcess(encoder: encoder, houseId: houseId)
         }
     }
 
@@ -147,7 +147,7 @@ final class ScanProcessingManager {
     // MARK: - Full Process
 
     @MainActor
-    private func fullProcess(encoder: DatasetEncoder, houseId: Int, scanType: String) async {
+    private func fullProcess(encoder: DatasetEncoder, houseId: Int) async {
         guard let scanRepository else { return }
 
         // 1. WrapUp
@@ -169,7 +169,7 @@ final class ScanProcessingManager {
         activeScan = ActiveScan(scanId: 0, houseId: houseId, phase: .uploading)
         let scanResult: ScanResult
         do {
-            scanResult = try await scanRepository.uploadScan(houseId: houseId, scanType: scanType, fileURL: zipURL)
+            scanResult = try await scanRepository.uploadScan(houseId: houseId, fileURL: zipURL)
         } catch {
             cleanup(zipURL: zipURL, datasetDir: datasetDir)
             activeScan = ActiveScan(scanId: 0, houseId: houseId, phase: .failed("업로드 실패: \(error.localizedDescription)"))

--- a/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanViewModel.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanViewModel.swift
@@ -28,7 +28,6 @@ final class ScanViewModel: NSObject {
 
     let session = ARSession()
     let houseId: Int
-    let scanType: String
 
     private let processingManager: ScanProcessingManager
     private let onStartConversion: () -> Void
@@ -49,12 +48,10 @@ final class ScanViewModel: NSObject {
 
     init(
         houseId: Int,
-        scanType: String,
         processingManager: ScanProcessingManager,
         onStartConversion: @escaping () -> Void
     ) {
         self.houseId = houseId
-        self.scanType = scanType
         self.processingManager = processingManager
         self.onStartConversion = onStartConversion
         super.init()
@@ -64,7 +61,6 @@ final class ScanViewModel: NSObject {
     convenience init(preview phase: Phase) {
         self.init(
             houseId: 0,
-            scanType: "IN",
             processingManager: ScanProcessingManager(),
             onStartConversion: {}
         )
@@ -113,8 +109,7 @@ final class ScanViewModel: NSObject {
         guard let encoder else { return }
         processingManager.startFullProcess(
             encoder: encoder,
-            houseId: houseId,
-            scanType: scanType
+            houseId: houseId
         )
         self.encoder = nil
         onStartConversion()

--- a/RoomLog/RoomLog/Features/Scan/Presentation/Views/ScanView.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/Views/ScanView.swift
@@ -13,14 +13,12 @@ struct ScanView: View {
 
     init(
         houseId: Int,
-        scanType: String,
         processingManager: ScanProcessingManager,
         onStartConversion: @escaping () -> Void
     ) {
         self._viewModel = .init(
             wrappedValue: ScanViewModel(
                 houseId: houseId,
-                scanType: scanType,
                 processingManager: processingManager,
                 onStartConversion: onStartConversion
             )

--- a/RoomLog/RoomLog/Utilities/PreviewMocks/PreviewMocks.swift
+++ b/RoomLog/RoomLog/Utilities/PreviewMocks/PreviewMocks.swift
@@ -11,8 +11,8 @@ import Foundation
 // MARK: - Mock ScanRepository
 
 final class MockScanRepository: ScanRepositoryProtocol {
-    func uploadScan(houseId: Int, scanType: String, fileURL: URL) async throws -> ScanResult {
-        ScanResult(scanId: 1, status: "COMPLETED", fileURL: "", scanType: scanType)
+    func uploadScan(houseId: Int, fileURL: URL) async throws -> ScanResult {
+        ScanResult(scanId: 1, status: "COMPLETED", fileURL: "", scanType: "")
     }
 
     func getScanStatus(scanId: Int) async throws -> String {


### PR DESCRIPTION
## ✨ PR 유형
- [x] 리팩토링: 서버 API 스펙 변경에 따른 scan_type 파라미터 제거

<br>

## 🛠️ 작업 내용
- `POST /scans` 요청에서 `scan_type` 쿼리 파라미터 제거
- `ScanResultResponseDTO`에서 `scan_type` 필드 제거 (서버 응답에 미포함)
- `ScanViewModel`, `ScanView`, `ScanProcessingManager`에서 `scanType` 전달 체인 제거
- `NavigationDestination.scan` 케이스에서 `scanType` 연관값 제거
- `RoomListView`에서 스캔 유형 선택 다이얼로그 제거, 바로 스캔 화면 진입
- 도메인 모델(`ScanResult`)은 프레젠테이션 영향 범위가 넓어 유지, DTO에서 빈 문자열 매핑

<br>

## 🔍 관련 이슈
- closed #81

<br>

## 📸 스크린샷 - UI작업인 경우만 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 스캔 프로세스를 간소화했습니다. 스캔 버튼 클릭 시 추가 선택 과정 없이 바로 스캔 화면으로 진입하도록 개선되어, 더 빠르고 직관적인 사용자 경험을 제공합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DGU-Team404/roomlog-ios/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->