### PR TITLE
[Feat] 스캔 취소 API 연동

### DIFF
--- a/RoomLog/RoomLog/Features/Scan/Data/Repositories/ScanRepository.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Repositories/ScanRepository.swift
@@ -51,4 +51,14 @@ final class ScanRepository: ScanRepositoryProtocol {
             throw RepositoryError.decodingError(detail: String(describing: error))
         }
     }
+
+    func cancelScan(scanId: Int) async throws {
+        let response = try await adapter.request(ScanTarget.cancelScan(scanId: scanId))
+        do {
+            let dto = try decoder.decode(APIResponse<EmptyResult>.self, from: response.data)
+            _ = try dto.unwrap()
+        } catch let error as DecodingError {
+            throw RepositoryError.decodingError(detail: String(describing: error))
+        }
+    }
 }

--- a/RoomLog/RoomLog/Features/Scan/Data/Target/ScanTarget.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Target/ScanTarget.swift
@@ -13,6 +13,7 @@ enum ScanTarget {
     case uploadScan(houseId: Int, fileURL: URL)
     case getScanStatus(scanId: Int)
     case getScanPreview(scanId: Int)
+    case cancelScan(scanId: Int)
 }
 
 extension ScanTarget: BaseTargetType {
@@ -24,12 +25,14 @@ extension ScanTarget: BaseTargetType {
             return "/scans/\(scanId)/status"
         case .getScanPreview(let scanId):
             return "/scans/\(scanId)/preview"
+        case .cancelScan(let scanId):
+            return "/scans/\(scanId)/cancel"
         }
     }
 
     var method: Moya.Method {
         switch self {
-        case .uploadScan:
+        case .uploadScan, .cancelScan:
             return .post
         case .getScanStatus, .getScanPreview:
             return .get
@@ -49,7 +52,7 @@ extension ScanTarget: BaseTargetType {
                 [formData],
                 urlParameters: ["house_id": houseId]
             )
-        case .getScanStatus, .getScanPreview:
+        case .getScanStatus, .getScanPreview, .cancelScan:
             return .requestPlain
         }
     }

--- a/RoomLog/RoomLog/Features/Scan/Domain/Interfaces/ScanRepositoryProtocol.swift
+++ b/RoomLog/RoomLog/Features/Scan/Domain/Interfaces/ScanRepositoryProtocol.swift
@@ -11,4 +11,5 @@ protocol ScanRepositoryProtocol {
     func uploadScan(houseId: Int, fileURL: URL) async throws -> ScanResult
     func getScanStatus(scanId: Int) async throws -> String
     func getScanPreview(scanId: Int) async throws -> String
+    func cancelScan(scanId: Int) async throws
 }

--- a/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
@@ -77,9 +77,16 @@ final class ScanProcessingManager {
     /// 진행 중인 스캔 취소
     @MainActor
     func cancel() {
+        let scanId = activeScan?.scanId ?? 0
         processingTask?.cancel()
         activeScan = nil
         clearPendingScan()
+
+        if scanId > 0 {
+            Task { [weak self] in
+                try? await self?.scanRepository?.cancelScan(scanId: scanId)
+            }
+        }
     }
 
     /// 완료된 스캔 소비 (저장 완료 후 호출)

--- a/RoomLog/RoomLog/Utilities/PreviewMocks/PreviewMocks.swift
+++ b/RoomLog/RoomLog/Utilities/PreviewMocks/PreviewMocks.swift
@@ -22,6 +22,8 @@ final class MockScanRepository: ScanRepositoryProtocol {
     func getScanPreview(scanId: Int) async throws -> String {
         ""
     }
+
+    func cancelScan(scanId: Int) async throws {}
 }
 
 // MARK: - Mock HomeUseCaseProvider


### PR DESCRIPTION
## ✨ PR 유형
- [x] 스캔 취소 시 서버 API 호출 기능 추가

<br>

## 🛠️ 작업 내용
- `ScanTarget`에 `cancelScan(scanId:)` 케이스 추가 (`POST /scans/{scanId}/cancel`)
- `ScanRepositoryProtocol` / `ScanRepository`에 `cancelScan` 메서드 추가
- `ScanProcessingManager.cancel()`에서 scanId가 유효할 때 서버에 취소 요청 전송
- `MockScanRepository`에 프로토콜 conformance 반영

<br>

## 🔍 관련 이슈
- closed #83

<br>

## 📸 스크린샷 - UI작업인 경우만 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 진행 중 또는 예약된 스캔을 취소할 수 있는 기능이 추가되었습니다. 사용자가 스캔을 취소하면 로컬 상태가 정리되며, 서버에 취소 요청이 전송됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DGU-Team404/roomlog-ios/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->