### PR TITLE
[Refactor] scanType 잔여 참조 전체 제거

### DIFF
--- a/RoomLog/RoomLog/Features/Home/Data/DTO/RoomDTO.swift
+++ b/RoomLog/RoomLog/Features/Home/Data/DTO/RoomDTO.swift
@@ -64,15 +64,13 @@ struct RoomSummaryDTO: Codable {
 
 struct LatestScanDTO: Codable {
     let scanId: Int
-    let scanType: String
 
     enum CodingKeys: String, CodingKey {
         case scanId = "scan_id"
-        case scanType = "scan_type"
     }
 
     func toDomain() -> LatestScan {
-        LatestScan(scanId: scanId, scanType: scanType)
+        LatestScan(scanId: scanId)
     }
 }
 
@@ -99,12 +97,10 @@ struct CreateRoomResponseDTO: Codable {
 struct LinkedScanDTO: Codable {
     let scanId: Int
     let status: String
-    let scanType: String
 
     enum CodingKeys: String, CodingKey {
         case scanId = "scan_id"
         case status
-        case scanType = "scan_type"
     }
 }
 

--- a/RoomLog/RoomLog/Features/Home/Domain/Models/Room.swift
+++ b/RoomLog/RoomLog/Features/Home/Domain/Models/Room.swift
@@ -20,7 +20,6 @@ struct RoomSummary: Identifiable {
 
 struct LatestScan {
     let scanId: Int
-    let scanType: String
 }
 
 // MARK: - Room Detail (상세 조회용)

--- a/RoomLog/RoomLog/Features/Scan/Data/DTO/ScanResultResponseDTO.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/DTO/ScanResultResponseDTO.swift
@@ -24,8 +24,7 @@ struct ScanResultResponseDTO: Codable {
         ScanResult(
             scanId: scanId,
             status: status,
-            fileURL: fileURL,
-            scanType: ""
+            fileURL: fileURL
         )
     }
 }

--- a/RoomLog/RoomLog/Features/Scan/Domain/Models/ScanResult.swift
+++ b/RoomLog/RoomLog/Features/Scan/Domain/Models/ScanResult.swift
@@ -11,5 +11,4 @@ struct ScanResult {
     let scanId: Int
     let status: String
     let fileURL: String
-    let scanType: String
 }

--- a/RoomLog/RoomLog/Utilities/PreviewMocks/PreviewMocks.swift
+++ b/RoomLog/RoomLog/Utilities/PreviewMocks/PreviewMocks.swift
@@ -12,7 +12,7 @@ import Foundation
 
 final class MockScanRepository: ScanRepositoryProtocol {
     func uploadScan(houseId: Int, fileURL: URL) async throws -> ScanResult {
-        ScanResult(scanId: 1, status: "COMPLETED", fileURL: "", scanType: "")
+        ScanResult(scanId: 1, status: "COMPLETED", fileURL: "")
     }
 
     func getScanStatus(scanId: Int) async throws -> String {
@@ -77,9 +77,9 @@ extension DIContainer {
 
 enum PreviewSampleData {
     static let rooms: [RoomSummary] = [
-        RoomSummary(id: 1, name: "거실", thumbnailURL: nil, latestScan: LatestScan(scanId: 1, scanType: "IN"), recentScanDate: Date(), latestScanStatus: "COMPLETED"),
+        RoomSummary(id: 1, name: "거실", thumbnailURL: nil, latestScan: LatestScan(scanId: 1), recentScanDate: Date(), latestScanStatus: "COMPLETED"),
         RoomSummary(id: 2, name: "안방", thumbnailURL: nil, latestScan: nil, recentScanDate: Date().addingTimeInterval(-86400), latestScanStatus: nil),
-        RoomSummary(id: 3, name: "주방", thumbnailURL: nil, latestScan: LatestScan(scanId: 3, scanType: "OUT"), recentScanDate: Date().addingTimeInterval(-172800), latestScanStatus: "COMPLETED"),
+        RoomSummary(id: 3, name: "주방", thumbnailURL: nil, latestScan: LatestScan(scanId: 3), recentScanDate: Date().addingTimeInterval(-172800), latestScanStatus: "COMPLETED"),
     ]
 
     static let defects: [DefectReportDetail] = [


### PR DESCRIPTION
## ✨ PR 유형
- [x] scanType 관련 잔여 코드 제거

<br>

## 🛠️ 작업 내용
- `ScanResult` 도메인 모델에서 `scanType` 프로퍼티 제거
- `ScanResultResponseDTO.toDomain()`에서 `scanType: ""` 하드코딩 제거
- `LatestScan` 도메인 모델에서 `scanType` 제거
- `LatestScanDTO`에서 `scanType` + CodingKey 제거 → 방 목록 디코딩 실패 해결
- `LinkedScanDTO`에서 `scanType` + CodingKey 제거
- `PreviewMocks` Mock 데이터 반영

<br>

## 🔍 관련 이슈
- closed #81

<br>

## 📸 스크린샷 - UI작업인 경우만 추가