### PR TITLE
[Feat] 스캔 UI 리퀴드글래스 적용 및 거리 경고 추가

### DIFF
--- a/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanViewModel.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanViewModel.swift
@@ -24,6 +24,10 @@ final class ScanViewModel: NSObject {
 
     private(set) var phase: Phase = .idle
     private(set) var recordingSeconds: Int = 0
+    private(set) var showDepthWarning: Bool = false
+    private var warningFrames: Int = 0
+    private var okFrames: Int = 0
+    private var totalFrameCount: Int = 0
     private var isPreview: Bool = false
 
     let session = ARSession()
@@ -149,6 +153,59 @@ final class ScanViewModel: NSObject {
 
 extension ScanViewModel: ARSessionDelegate {
     func session(_ session: ARSession, didUpdate frame: ARFrame) {
+        updateDepthWarning(frame: frame)
         encoder?.add(frame: frame)
+    }
+
+    private func updateDepthWarning(frame: ARFrame) {
+        totalFrameCount += 1
+        guard totalFrameCount > 60 else { return }
+
+        guard let depthMap = frame.sceneDepth?.depthMap else {
+            warningFrames += 1
+            okFrames = 0
+            if !showDepthWarning && warningFrames >= 10 {
+                showDepthWarning = true
+            }
+            return
+        }
+
+        let width = CVPixelBufferGetWidth(depthMap)
+        let height = CVPixelBufferGetHeight(depthMap)
+        CVPixelBufferLockBaseAddress(depthMap, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(depthMap, .readOnly) }
+        guard let base = CVPixelBufferGetBaseAddress(depthMap) else { return }
+        let buffer = base.assumingMemoryBound(to: Float32.self)
+
+        let cx = width / 2, cy = height / 2
+        let range = width / 6
+        let step = 3
+
+        var samples: [Float] = []
+        for y in stride(from: cy - range, to: cy + range, by: step) {
+            for x in stride(from: cx - range, to: cx + range, by: step) {
+                let d = buffer[y * width + x]
+                if d > 0 && !d.isNaN && d < 10 {
+                    samples.append(d)
+                }
+            }
+        }
+        samples.sort()
+        let medianDepth = samples.isEmpty ? 0 : samples[samples.count / 2]
+        let isBad = medianDepth < 0.20
+
+        if isBad {
+            warningFrames += 1
+            okFrames = 0
+            if !showDepthWarning && warningFrames >= 10 {
+                showDepthWarning = true
+            }
+        } else {
+            okFrames += 1
+            warningFrames = 0
+            if showDepthWarning && okFrames >= 20 {
+                showDepthWarning = false
+            }
+        }
     }
 }

--- a/RoomLog/RoomLog/Features/Scan/Presentation/Views/ScanView.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/Views/ScanView.swift
@@ -66,11 +66,26 @@ struct ScanView: View {
     // MARK: - Scan Phase
 
     private var scanPhase: some View {
-        ZStack(alignment: .bottom) {
+        ZStack {
             ARViewContainer(session: viewModel.session)
                 .ignoresSafeArea()
 
+            if viewModel.showDepthWarning {
+                VStack(spacing: 8) {
+                    Image(systemName: "hand.raised.fill")
+                        .font(.title2)
+                    Text("조금 더 떨어져주세요")
+                        .font(.semibold, 15)
+                }
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 14)
+                .glassEffect(.regular, in: .capsule)
+                .animation(.easeInOut(duration: 0.3), value: viewModel.showDepthWarning)
+            }
+
             VStack(spacing: 20) {
+                Spacer()
                 statusBadge
                 controls
             }
@@ -88,7 +103,10 @@ struct ScanView: View {
         case .recording:
             Label(recordingTimeString, systemImage: "record.circle.fill")
                 .foregroundStyle(.red)
-                .badgeStyle()
+                .font(.subheadline)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .glassEffect(.regular, in: .capsule)
         case .recorded:
             EmptyView()
         }
@@ -116,8 +134,9 @@ struct ScanView: View {
         } label: {
             Circle()
                 .fill(.red)
-                .frame(width: 72, height: 72)
-                .overlay(Circle().strokeBorder(.white, lineWidth: 4))
+                .frame(width: 52, height: 52)
+                .frame(width: 68, height: 68)
+                .glassEffect(.regular.interactive(), in: .circle)
         }
     }
 
@@ -125,26 +144,12 @@ struct ScanView: View {
         Button {
             viewModel.stopRecording()
         } label: {
-            ZStack {
-                Circle()
-                    .strokeBorder(.white, lineWidth: 4)
-                    .frame(width: 72, height: 72)
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(.red)
-                    .frame(width: 30, height: 30)
-            }
+            RoundedRectangle(cornerRadius: 6)
+                .fill(.red)
+                .frame(width: 32, height: 32)
+                .frame(width: 68, height: 68)
+                .glassEffect(.regular.interactive(), in: .circle)
         }
     }
 }
 
-// MARK: - View Extension
-
-private extension View {
-    func badgeStyle() -> some View {
-        self
-            .font(.subheadline)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
-            .background(.ultraThinMaterial, in: Capsule())
-    }
-}


### PR DESCRIPTION
## ✨ PR 유형
- [x] 스캔 화면 UI 개선

<br>

## 🛠️ 작업 내용
- 촬영/정지 버튼을 `glassEffect`로 변경
- 녹화 시간 배지를 `glassEffect`로 변경 (기존 `ultraThinMaterial` 제거)
- LiDAR depth 기반 근접 경고 추가 (median depth < 0.20m, 히스테리시스 적용)

<br>

## 🔍 관련 이슈
- closed #86

<br>

## 📸 스크린샷 - UI작업인 경우만 추가
<img width="117" height="255" alt="image" src="https://github.com/user-attachments/assets/a3c325b1-9f91-4ff1-88f6-cf55e480f51c" />
