### PR TITLE
[Feat] AI 분석 로딩 상태 처리 UI 구현

### DIFF
--- a/RoomLog/RoomLog/Core/Common/UIComponents/AnalysisLoadingView.swift
+++ b/RoomLog/RoomLog/Core/Common/UIComponents/AnalysisLoadingView.swift
@@ -1,0 +1,75 @@
+//
+//  AnalysisLoadingView.swift
+//  RoomLog
+//
+//  Created by minkyo on 5/23/26.
+//
+
+import SwiftUI
+
+/// AI 분석 대기 중 공통 로딩 UI
+/// 상단에 커스텀 콘텐츠(3D 이미지 등)를 넣고, 하단은 로딩 placeholder를 표시
+struct AnalysisLoadingView<TopContent: View>: View {
+    let message: String
+    let placeholderCount: Int
+    @ViewBuilder let topContent: () -> TopContent
+
+    init(
+        message: String = "AI가 분석하고 있습니다...",
+        placeholderCount: Int = 3,
+        @ViewBuilder topContent: @escaping () -> TopContent
+    ) {
+        self.message = message
+        self.placeholderCount = placeholderCount
+        self.topContent = topContent
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                topContent()
+
+                VStack(spacing: 16) {
+                    ProgressView()
+                    Text(message)
+                        .font(.medium, 14)
+                        .foregroundStyle(Color.blueGray400)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 32)
+                .background(.white, in: RoundedRectangle(cornerRadius: 20))
+                .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 2)
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("감지된 하자")
+                        .font(.semibold, 20)
+                        .foregroundStyle(Color.neutral800)
+
+                    ForEach(0..<placeholderCount, id: \.self) { _ in
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color.blueGray50)
+                            .frame(maxWidth: .infinity)
+                            .aspectRatio(370.0 / 100.0, contentMode: .fit)
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+            .padding(.bottom, 16)
+        }
+    }
+}
+
+#Preview {
+    AnalysisLoadingView {
+        RoundedRectangle(cornerRadius: 12)
+            .fill(Color.blueGray50)
+            .frame(maxWidth: .infinity)
+            .aspectRatio(16 / 10, contentMode: .fit)
+            .overlay {
+                Image(systemName: "cube.transparent")
+                    .font(.system(size: 40))
+                    .foregroundStyle(Color.blueGray300)
+            }
+    }
+}

--- a/RoomLog/RoomLog/Features/Defect/Presentation/DefectViewModel/DefectViewModel.swift
+++ b/RoomLog/RoomLog/Features/Defect/Presentation/DefectViewModel/DefectViewModel.swift
@@ -34,9 +34,6 @@ final class DefectViewModel {
 
     // MARK: - Function
     func fetchReport() async {
-        phase = .loading
-
-        // 3D 이미지는 즉시 표시하기 위해 기본 정보 먼저 로드
         do {
             report = try await provider.makeGetDefectReportUseCase().execute(roomId: roomId)
             phase = .completed
@@ -48,6 +45,7 @@ final class DefectViewModel {
 
     /// 목데이터용: polling 시뮬레이션 (API 연동 시 실제 polling으로 교체)
     func startAnalysis() async {
+        guard phase != .polling, phase != .loading else { return }
         phase = .polling
 
         // 3D 이미지용 기본 report 먼저 로드

--- a/RoomLog/RoomLog/Features/Defect/Presentation/DefectViewModel/DefectViewModel.swift
+++ b/RoomLog/RoomLog/Features/Defect/Presentation/DefectViewModel/DefectViewModel.swift
@@ -9,14 +9,23 @@ import Foundation
 
 @Observable
 final class DefectViewModel {
+    // MARK: - Analysis Phase
+    enum AnalysisPhase: Equatable {
+        case loading
+        case polling
+        case completed
+        case failed(String)
+    }
+
     // MARK: - State
     private(set) var report: DefectReport?
-    private(set) var isLoading = false
+    private(set) var phase: AnalysisPhase = .loading
     var errorMessage: String?
 
     // MARK: - Provider
     let roomId: Int
     private let provider: DefectUseCaseProvider
+    private var pollingTask: Task<Void, Never>?
 
     init(roomId: Int, provider: DefectUseCaseProvider) {
         self.roomId = roomId
@@ -25,13 +34,59 @@ final class DefectViewModel {
 
     // MARK: - Function
     func fetchReport() async {
-        isLoading = true
-        defer { isLoading = false }
+        phase = .loading
+
+        // 3D 이미지는 즉시 표시하기 위해 기본 정보 먼저 로드
         do {
             report = try await provider.makeGetDefectReportUseCase().execute(roomId: roomId)
+            phase = .completed
         } catch {
             errorMessage = error.localizedDescription
+            phase = .failed(error.localizedDescription)
         }
     }
 
+    /// 목데이터용: polling 시뮬레이션 (API 연동 시 실제 polling으로 교체)
+    func startAnalysis() async {
+        phase = .polling
+
+        // 3D 이미지용 기본 report 먼저 로드
+        do {
+            let baseReport = try await provider.makeGetDefectReportUseCase().execute(roomId: roomId)
+            report = DefectReport(
+                room: baseReport.room,
+                imageURL: baseReport.imageURL,
+                defectCount: 0,
+                minRepairCost: 0,
+                repairArea: 0,
+                defects: []
+            )
+        } catch {
+            phase = .failed(error.localizedDescription)
+            return
+        }
+
+        // polling 시뮬레이션: 3초 후 완료
+        try? await Task.sleep(for: .seconds(3))
+
+        if Task.isCancelled { return }
+
+        // 완료 후 전체 데이터 로드
+        await fetchReport()
+    }
+
+    func cancelPolling() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+
+    #if DEBUG
+    /// Preview 전용: 특정 phase로 고정된 ViewModel 생성
+    static func preview(phase: AnalysisPhase, report: DefectReport?, provider: DefectUseCaseProvider) -> DefectViewModel {
+        let vm = DefectViewModel(roomId: 1, provider: provider)
+        vm.phase = phase
+        vm.report = report
+        return vm
+    }
+    #endif
 }

--- a/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectView.swift
+++ b/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectView.swift
@@ -10,25 +10,46 @@ import SwiftUI
 struct DefectView: View {
     @Environment(\.di) var di
     @State private var viewModel: DefectViewModel
+    private let skipAutoLoad: Bool
 
     init(roomId: Int, provider: DefectUseCaseProvider) {
         self._viewModel = .init(
             wrappedValue: DefectViewModel(roomId: roomId, provider: provider)
         )
+        self.skipAutoLoad = false
     }
+
+    #if DEBUG
+    init(viewModel: DefectViewModel) {
+        self._viewModel = .init(wrappedValue: viewModel)
+        self.skipAutoLoad = true
+    }
+    #endif
 
     var body: some View {
         Group {
-            if let report = viewModel.report {
-                content(report: report)
-            } else {
+            switch viewModel.phase {
+            case .loading:
                 ProgressView()
+            case .polling:
+                if let report = viewModel.report {
+                    pollingContent(report: report)
+                } else {
+                    ProgressView()
+                }
+            case .completed:
+                if let report = viewModel.report {
+                    content(report: report)
+                }
+            case .failed(let message):
+                errorView(message: message)
             }
         }
         .navigationTitle(viewModel.report.map { "\($0.room.title) 하자" } ?? "하자 점검")
         .navigationBarTitleDisplayMode(.inline)
         .task {
-            await viewModel.fetchReport()
+            guard !skipAutoLoad, viewModel.phase == .loading else { return }
+            await viewModel.startAnalysis()
         }
     }
 
@@ -75,15 +96,44 @@ struct DefectView: View {
                 .font(.semibold, 17)
         }
     }
+
+    // MARK: - Polling Content (3D 이미지만 표시 + 나머지 로딩)
+
+    @ViewBuilder
+    private func pollingContent(report: DefectReport) -> some View {
+        AnalysisLoadingView(message: "AI가 하자를 분석하고 있습니다...") {
+            imageSection(report: report)
+        }
+    }
+
+    // MARK: - Error View
+
+    private func errorView(message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(Color.blueGray300)
+            Text("분석에 실패했습니다")
+                .font(.semibold, 18)
+                .foregroundStyle(Color.neutral800)
+            Text(message)
+                .font(.medium, 14)
+                .foregroundStyle(Color.blueGray400)
+                .multilineTextAlignment(.center)
+            Button {
+                Task { await viewModel.startAnalysis() }
+            } label: {
+                Text("다시 시도")
+                    .font(.semibold, 16)
+                    .foregroundStyle(Color.accentColor)
+            }
+        }
+        .padding(32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
 }
 
-#Preview {
-    let di = DIContainer.configured()
-    NavigationStack {
-        DefectView(roomId: 1, provider: di.resolve(DefectUseCaseProvider.self))
-    }
-    .environment(\.di, di)
-}
+
 
 // MARK: - Section 1: 이미지 + 마커
 // TODO: - 추후 3d이미지로 불러오기 및 마커 수정 - @minkyo
@@ -199,7 +249,7 @@ private extension DefectView {
                         Text("전체보기")
                             .font(.semibold, 14)
                         Image(systemName: "chevron.right")
-                            .font(.system(size: 11, weight: .semibold))
+                            .font(.semibold, 11)
                     }
                     .foregroundStyle(Color.mutedBlue)
                 }
@@ -232,3 +282,36 @@ private struct SummaryStatView: View {
     }
 }
 
+#Preview("기본") {
+    let di = DIContainer.configured()
+    NavigationStack {
+        DefectView(roomId: 1, provider: di.resolve(DefectUseCaseProvider.self))
+    }
+    .environment(\.di, di)
+}
+
+#Preview("Polling 상태") {
+    let di = DIContainer.configured()
+    let vm = DefectViewModel.preview(
+        phase: .polling,
+        report: PreviewSampleData.pollingReport,
+        provider: di.resolve(DefectUseCaseProvider.self)
+    )
+    NavigationStack {
+        DefectView(viewModel: vm)
+    }
+    .environment(\.di, di)
+}
+
+#Preview("실패 상태") {
+    let di = DIContainer.configured()
+    let vm = DefectViewModel.preview(
+        phase: .failed("서버에서 분석에 실패했습니다"),
+        report: nil,
+        provider: di.resolve(DefectUseCaseProvider.self)
+    )
+    NavigationStack {
+        DefectView(viewModel: vm)
+    }
+    .environment(\.di, di)
+}

--- a/RoomLog/RoomLog/Utilities/PreviewMocks/PreviewMocks.swift
+++ b/RoomLog/RoomLog/Utilities/PreviewMocks/PreviewMocks.swift
@@ -102,5 +102,17 @@ enum PreviewSampleData {
             defects: defects
         )
     }
+
+    /// Polling 중 상태: 3D 이미지만 있고 하자 데이터는 비어있는 report
+    static var pollingReport: DefectReport {
+        DefectReport(
+            room: DefectRoomData(id: 1, title: "망고의 방", date: Date(), thumbnailURL: nil),
+            imageURL: nil,
+            defectCount: 0,
+            minRepairCost: 0,
+            repairArea: 0,
+            defects: []
+        )
+    }
 }
 #endif


### PR DESCRIPTION
## ✨ PR 유형
- [ ] AI 분석 로딩 상태 처리 UI 구현

<br>

## 🛠️ 작업 내용
  - DefectViewModel: AnalysisPhase 상태 (loading/polling/completed/failed)                 
  - DefectView: phase별 UI 분기 (3D 이미지 즉시 표시, 나머지 로딩)                         
  - AnalysisLoadingView: 공통 컴포넌트 (내방비교에서도 재사용 가능)                        
  - 에러 화면 + 다시 시도 버튼                                                              
  - 뒤로가기 시 재로딩 방지                                                                 
  - Preview 3개 (기본/Polling/실패)    

<br>

## 🔍 관련 이슈
- closed #92 

<br>

## 📸 스크린샷 - UI작업인 경우만 추가
<table>
<tr>
<td>
<b>polling state</b>
</td>
<td>
<b>fail state</b>
</td>
</tr>
<tr>
<td>
<img width="282" height="571" alt="스크린샷 2026-05-23 00 50 48" src="https://github.com/user-attachments/assets/3838d8ce-0e15-4d04-9060-c61bb7b57322" />
</td>
<td>
<img width="279" height="578" alt="스크린샷 2026-05-23 00 54 55" src="https://github.com/user-attachments/assets/8c112b63-b922-4897-8584-c0a41d0cd97e" />

</td>
</tr>
</table>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 결함 분석 과정의 상태 표시 개선: 분석 중, 처리 중, 완료, 오류 상태를 명확하게 구분하여 표시합니다.
  * 분석 실패 시 오류 메시지 표시 및 재시도 기능을 추가했습니다.
  * 분석 진행 중 향상된 로딩 UI를 제공합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DGU-Team404/roomlog-ios/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->