### PR TITLE
[Fix] 스캔 UX 개선 - 프리뷰 버튼, 녹화 프레임 제어, 중복 스캔 방지

### DIFF
--- a/RoomLog/RoomLog/Features/Home/Presentation/Views/RoomListView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Views/RoomListView.swift
@@ -248,6 +248,15 @@ struct RoomListView: View {
             .sheet(isPresented: $showProcessingStatus) {
                 scanStatusSheet(active: active)
             }
+        } else if processingManager.activeScan != nil {
+            BottomCTAButton { } label: {
+                HStack(spacing: 8) {
+                    Image(.scan)
+                    Text("다른 집에서 스캔 진행 중")
+                        .font(.semibold, 16)
+                }
+            }
+            .disabled(true)
         } else {
             BottomCTAButton {
                 pathStore.homePath.append(.home(.scan(houseId: viewModel.houseId)))

--- a/RoomLog/RoomLog/Features/Scan/Data/DTO/ScanPreviewResponseDTO.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/DTO/ScanPreviewResponseDTO.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct ScanPreviewResponseDTO: Codable {
     let scanId: Int
-    let roomId: Int
+    let roomId: Int?
     let fileURL: String
     let createdAt: String
 

--- a/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanViewModel.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanViewModel.swift
@@ -79,6 +79,15 @@ final class ScanViewModel: NSObject {
         guard !isPreview else { return }
         session.delegate = self
         session.run(configuration)
+        prepareEncoder()
+    }
+
+    private func prepareEncoder() {
+        do {
+            encoder = try DatasetEncoder(arConfiguration: configuration)
+        } catch {
+            print("ScanViewModel: 인코더 사전 준비 실패. \(error.localizedDescription)")
+        }
     }
 
     func tearDown() {
@@ -89,11 +98,8 @@ final class ScanViewModel: NSObject {
     // MARK: - Recording
 
     func startRecording() {
-        do {
-            encoder = try DatasetEncoder(arConfiguration: configuration)
-        } catch {
-            return
-        }
+        if encoder == nil { prepareEncoder() }
+        guard encoder != nil else { return }
         startIMU()
         recordingSeconds = 0
         recordingTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
@@ -124,6 +130,7 @@ final class ScanViewModel: NSObject {
         recordingTimer = nil
         encoder = nil
         phase = .idle
+        prepareEncoder()
     }
 
     // MARK: - IMU
@@ -154,6 +161,7 @@ final class ScanViewModel: NSObject {
 extension ScanViewModel: ARSessionDelegate {
     func session(_ session: ARSession, didUpdate frame: ARFrame) {
         updateDepthWarning(frame: frame)
+        guard phase == .recording else { return }
         encoder?.add(frame: frame)
     }
 

--- a/RoomLog/RoomLog/Features/Scan/Presentation/Views/ScanPreviewView.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/Views/ScanPreviewView.swift
@@ -64,17 +64,22 @@ struct ScanPreviewView: View {
         }
         .navigationTitle("3D 미리보기")
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
-                Button("다시 스캔") {
+                Button {
                     showRescanAlert = true
+                } label: {
+                    Image(systemName: "arrow.counterclockwise")
                 }
                 .disabled(isSaving)
             }
             ToolbarItem(placement: .topBarTrailing) {
-                Button("저장하기") {
+                Button {
                     roomName = ""
                     showSaveAlert = true
+                } label: {
+                    Image(systemName: "square.and.arrow.down")
                 }
                 .disabled(isSaving)
             }


### PR DESCRIPTION
## ✨ PR 유형
- [x] UX 개선 / 버그 수정

<br>

## 🛠️ 작업 내용
- ScanPreviewView: 텍스트 버튼(다시스캔/저장하기)을 SF Symbol 아이콘으로 변경, 기본 뒤로가기 버튼 숨김
- ScanViewModel: `phase == .recording` 가드로 녹화 중지 후 프레임 누수 방지, `setup()` 시 인코더 사전 초기화로 녹화 시작 렉 개선
- RoomListView: 다른 집에서 스캔 진행 중일 때 CTA 버튼을 "다른 집에서 스캔 진행 중"으로 비활성화
- ScanPreviewResponseDTO: `roomId` nullable 처리 (방 생성 전 스캔 완료 시 null 응답 대응)

<br>

## 🔍 관련 이슈
- closed #95

<br>

## 📸 스크린샷 - UI작업인 경우만 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 다른 집에서 스캔이 진행 중일 때, 스캔 시작 버튼을 비활성화 상태로 표시하여 사용자에게 명확한 피드백을 제공합니다.

* **버그 수정**
  * 스캔 응답에서 방 ID가 누락된 경우를 올바르게 처리합니다.

* **사용자 인터페이스 개선**
  * 스캔 미리보기 화면의 네비게이션 버튼을 텍스트에서 시스템 아이콘으로 변경했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DGU-Team404/roomlog-ios/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->