### PR TITLE
[Feat] viewer 화면 house 선택 기능 추가

### DIFF
--- a/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerView.swift
+++ b/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerView.swift
@@ -31,13 +31,51 @@ struct ViewerView: View {
                     .scaledToFit()
                     .frame(height: 28)
             }
+            ToolbarItem(placement: .topBarTrailing) {
+                houseDropdown
+            }
         }
         .onAppear {
             if viewModel == nil {
-                let useCase = di.resolve(DefectUseCaseProvider.self).makeGetDefectRoomDataUseCase()
-                viewModel = ViewerViewModel(useCase: useCase)
+                viewModel = ViewerViewModel(
+                    defectProvider: di.resolve(DefectUseCaseProvider.self),
+                    homeProvider: di.resolve(HomeUseCaseProvider.self)
+                )
             }
-            Task { await viewModel?.fetchRooms() }
+            Task {
+                await viewModel?.fetchHouses()
+                await viewModel?.fetchRooms()
+            }
+        }
+    }
+}
+
+// MARK: - House Dropdown
+
+private extension ViewerView {
+    var houseDropdown: some View {
+        Menu {
+            ForEach(viewModel?.houses ?? []) { house in
+                Button {
+                    viewModel?.selectedHouse = house
+                    Task { await viewModel?.fetchRooms() }
+                } label: {
+                    HStack {
+                        Text(house.name)
+                        if viewModel?.selectedHouse?.id == house.id {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(viewModel?.selectedHouse != nil ? "\(viewModel!.selectedHouseDisplayName)의 집" : "집 선택")
+                    .font(.medium, 16)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 10, weight: .medium))
+            }
+            .foregroundStyle(Color.neutral800)
         }
     }
 }

--- a/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerViewModel.swift
+++ b/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerViewModel.swift
@@ -27,7 +27,10 @@ final class ViewerViewModel {
         do {
             let houseList = try await homeProvider.makeGetHousesUseCase().execute()
             houses = houseList.houses
-            if selectedHouse == nil || !houseList.houses.contains(where: { $0.id == selectedHouse?.id }) {
+            if let currentId = selectedHouse?.id,
+               let refreshed = houseList.houses.first(where: { $0.id == currentId }) {
+                selectedHouse = refreshed
+            } else {
                 selectedHouse = houseList.mainHouse ?? houseList.houses.first
             }
         } catch {

--- a/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerViewModel.swift
+++ b/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 @Observable
+@MainActor
 final class ViewerViewModel {
     private(set) var rooms: [DefectRoomData] = []
     private(set) var houses: [House] = []
@@ -26,7 +27,7 @@ final class ViewerViewModel {
         do {
             let houseList = try await homeProvider.makeGetHousesUseCase().execute()
             houses = houseList.houses
-            if selectedHouse == nil {
+            if selectedHouse == nil || !houseList.houses.contains(where: { $0.id == selectedHouse?.id }) {
                 selectedHouse = houseList.mainHouse ?? houseList.houses.first
             }
         } catch {

--- a/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerViewModel.swift
+++ b/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerViewModel.swift
@@ -10,21 +10,45 @@ import Foundation
 @Observable
 final class ViewerViewModel {
     private(set) var rooms: [DefectRoomData] = []
+    private(set) var houses: [House] = []
     private(set) var isLoading = false
+    var selectedHouse: House?
 
-    private let useCase: GetDefectRoomDataUseCaseProtocol
+    private let defectProvider: DefectUseCaseProvider
+    private let homeProvider: HomeUseCaseProvider
 
-    init(useCase: GetDefectRoomDataUseCaseProtocol) {
-        self.useCase = useCase
+    init(defectProvider: DefectUseCaseProvider, homeProvider: HomeUseCaseProvider) {
+        self.defectProvider = defectProvider
+        self.homeProvider = homeProvider
+    }
+
+    func fetchHouses() async {
+        do {
+            let houseList = try await homeProvider.makeGetHousesUseCase().execute()
+            houses = houseList.houses
+            if selectedHouse == nil {
+                selectedHouse = houseList.mainHouse ?? houseList.houses.first
+            }
+        } catch {
+            // TODO: 에러 처리
+        }
     }
 
     func fetchRooms() async {
         isLoading = true
         defer { isLoading = false }
         do {
-            rooms = try await useCase.execute()
+            rooms = try await defectProvider.makeGetDefectRoomDataUseCase().execute()
         } catch {
-            // TODO: 추후 추가 - @minkyo
+            // TODO: 에러 처리
         }
+    }
+
+    var selectedHouseDisplayName: String {
+        guard let name = selectedHouse?.name else { return "집 선택" }
+        if name.count > 4 {
+            return String(name.prefix(4)) + "..."
+        }
+        return name
     }
 }


### PR DESCRIPTION
## ✨ PR 유형
- [x] <!-- 변경 사항 작성 --> UI 구현

<br>

## 🛠️ 작업 내용
- <!-- 작업 내용 작성 -->
-  House 드롭다운 UI                                                                       
- House 목록 조회 + 선택 상태 관리   

<br>

## 🔍 관련 이슈
- closed #94 

<br>

## 📸 스크린샷 - UI작업인 경우만 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 상단 드롭다운에서 집을 선택해 해당 집의 최근 점검 목록을 조회할 수 있으며, 선택 시 목록이 자동으로 갱신됩니다.
  * 집 이름이 길면 표시를 축약해 UI에 깔끔하게 보여줍니다.

* **리팩터**
  * 화면 진입 시 집 목록과 점검 목록을 순차적으로 불러와 초기화 흐름을 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DGU-Team404/roomlog-ios/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->