### PR TITLE
[Feat] viewer 방목록 API 연동 및 houseId 상태 공유

### DIFF
--- a/RoomLog/RoomLog/Features/Home/Presentation/ViewModels/HomeState.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/ViewModels/HomeState.swift
@@ -11,4 +11,5 @@ import Observation
 @Observable
 final class HomeState {
     var hasHouses: Bool = false
+    var selectedHouse: House?
 }

--- a/RoomLog/RoomLog/Features/Home/Presentation/Views/HomeView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Views/HomeView.swift
@@ -28,6 +28,7 @@ struct HomeView: View {
 
     var body: some View {
         HouseMapView(houses: viewModel.houses, mainHouseId: viewModel.mainHouse?.houseId, namespace: houseNamespace) { house in
+            homeState.selectedHouse = house
             pathStore.homePath.append(.home(.roomList(houseId: house.houseId, houseName: house.name)))
         }
         .navigationDestination(for: NavigationDestination.self) { dest in

--- a/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerView.swift
+++ b/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerView.swift
@@ -38,8 +38,8 @@ struct ViewerView: View {
         .onAppear {
             if viewModel == nil {
                 viewModel = ViewerViewModel(
-                    defectProvider: di.resolve(DefectUseCaseProvider.self),
-                    homeProvider: di.resolve(HomeUseCaseProvider.self)
+                    homeProvider: di.resolve(HomeUseCaseProvider.self),
+                    homeState: di.resolve(HomeState.self)
                 )
             }
             Task {
@@ -70,7 +70,7 @@ private extension ViewerView {
             }
         } label: {
             HStack(spacing: 4) {
-                Text(viewModel?.selectedHouse != nil ? "\(viewModel!.selectedHouseDisplayName)의 집" : "집 선택")
+                Text(viewModel?.selectedHouse != nil ? "\(viewModel!.selectedHouseDisplayName)" : "집 선택")
                     .font(.medium, 16)
                 Image(systemName: "chevron.up.chevron.down")
                     .font(.system(size: 10, weight: .medium))
@@ -214,23 +214,17 @@ private extension ViewerView {
 // MARK: - 최근 점검 Row
 
 private struct RecentRoomRow: View {
-    let room: DefectRoomData
+    let room: RoomSummary
     let onTap: () -> Void
-
-    private static let dateFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "yyyy.MM.dd"
-        return f
-    }()
 
     var body: some View {
         HStack(spacing: 16) {
             thumbnailView
             VStack(alignment: .leading, spacing: 16) {
-                Text(room.title)
+                Text(room.name)
                     .font(.semibold, 16)
                     .foregroundStyle(Color.neutral800)
-                Text(Self.dateFormatter.string(from: room.date))
+                Text(room.recentScanDate?.toShortDisplayString() ?? "-")
                     .font(.medium, 14)
                     .foregroundStyle(Color.blueGray300)
             }
@@ -259,10 +253,10 @@ private struct RecentRoomRow: View {
     }
 
     private var placeholder: some View {
-        Color(.systemGray5)
+        Color.blueGray50
             .overlay {
                 Image(systemName: "house.fill")
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(Color.blueGray300)
             }
     }
 }

--- a/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerViewModel.swift
+++ b/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerViewModel.swift
@@ -10,17 +10,21 @@ import Foundation
 @Observable
 @MainActor
 final class ViewerViewModel {
-    private(set) var rooms: [DefectRoomData] = []
+    private(set) var rooms: [RoomSummary] = []
     private(set) var houses: [House] = []
     private(set) var isLoading = false
-    var selectedHouse: House?
 
-    private let defectProvider: DefectUseCaseProvider
     private let homeProvider: HomeUseCaseProvider
+    private let homeState: HomeState
 
-    init(defectProvider: DefectUseCaseProvider, homeProvider: HomeUseCaseProvider) {
-        self.defectProvider = defectProvider
+    init(homeProvider: HomeUseCaseProvider, homeState: HomeState) {
         self.homeProvider = homeProvider
+        self.homeState = homeState
+    }
+
+    var selectedHouse: House? {
+        get { homeState.selectedHouse }
+        set { homeState.selectedHouse = newValue }
     }
 
     func fetchHouses() async {
@@ -39,10 +43,12 @@ final class ViewerViewModel {
     }
 
     func fetchRooms() async {
+        guard let houseId = selectedHouse?.id else { return }
         isLoading = true
         defer { isLoading = false }
         do {
-            rooms = try await defectProvider.makeGetDefectRoomDataUseCase().execute()
+            let houseRooms = try await homeProvider.makeGetHouseRoomsUseCase().execute(houseId: houseId)
+            rooms = houseRooms.rooms
         } catch {
             // TODO: 에러 처리
         }

--- a/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerViewModel.swift
+++ b/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerViewModel.swift
@@ -43,7 +43,10 @@ final class ViewerViewModel {
     }
 
     func fetchRooms() async {
-        guard let houseId = selectedHouse?.id else { return }
+        guard let houseId = selectedHouse?.id else {
+            rooms = []
+            return
+        }
         isLoading = true
         defer { isLoading = false }
         do {


### PR DESCRIPTION
## ✨ PR 유형
- [x] <!-- 변경 사항 작성 --> viewer 방목록 API 연동

<br>

## 🛠️ 작업 내용
- <!-- 작업 내용 작성 -->ViewerView 방 목록 조회를 /houses/{houseId}/rooms API로 연동  
-  Home에서 선택한 집을 HomeState로 공유하여 Viewer 탭에서 동일한 집의 방 목록 표시 
- ViewerViewModel에서 defectProvider 제거, homeProvider만 사용하도록 정리

<br>

## 🔍 관련 이슈
- closed #100 

<br>

## 📸 스크린샷 - UI작업인 경우만 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 선택한 집이 앱 전체에서 일관되게 유지되어 사용자 경험이 개선되었습니다.

* **개선사항**
  * 뷰어 화면의 집 선택 표시 방식이 간소화되었습니다.
  * 최근 점검 내역의 날짜 표시 형식이 더욱 명확해졌습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DGU-Team404/roomlog-ios/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->