### PR TITLE
[Design] Viewer 잠금 토스트 반응형 수정

### DIFF
--- a/RoomLog/RoomLog/Features/Home/Presentation/Components/ToastView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Components/ToastView.swift
@@ -26,3 +26,18 @@ struct ToastView<Label: View>: View {
         .shadow(color: .black.opacity(0.1), radius: 5, y: 2)
     }
 }
+
+#Preview {
+    ToastView {
+        HStack(spacing: 0) {
+            Text("집을 추가한 뒤 ").foregroundStyle(.neutral600)
+            Text("Viewer").foregroundStyle(.dustyBlue)
+            Text("를 사용하실 수 있습니다").foregroundStyle(.neutral600)
+        }
+        .font(.medium, 14)
+        .lineLimit(1)
+        .fixedSize(horizontal: true, vertical: false)
+    }
+    .padding(.horizontal, 24)
+}
+

--- a/RoomLog/RoomLog/Features/Tab/Presentation/RoomLogTab.swift
+++ b/RoomLog/RoomLog/Features/Tab/Presentation/RoomLogTab.swift
@@ -56,26 +56,27 @@ struct RoomLogTab: View {
         .overlay(alignment: .top) {
             if showViewerLockedToast {
                 ToastView {
-                        Group {
-                            Text("집을 추가한 뒤 ")
-                                .foregroundStyle(.neutral600)
-                            Text("Viewer")
-                                .foregroundStyle(.dustyBlue)
-                            Text("를 사용하실 수 있습니다")
-                                .foregroundStyle(.neutral600)
-                        }
-                        .font(.medium, 14)
+                    HStack(spacing: 0) {
+                        Text("집을 추가한 뒤 ")
+                            .foregroundStyle(.neutral600)
+                        Text("Viewer")
+                            .foregroundStyle(.dustyBlue)
+                        Text("를 사용하실 수 있습니다")
+                            .foregroundStyle(.neutral600)
                     }
-                    .padding(.horizontal, 24)
-                    .padding(.top, 60)
-                    .transition(.move(edge: .top).combined(with: .opacity))
-                    .onAppear {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
-                            withAnimation {
-                                showViewerLockedToast = false
-                            }
-                        }
+                    .font(.medium, 14)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                }
+                .padding(.horizontal, 24)
+                .safeAreaPadding(.top, 12)
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .task {
+                    try? await Task.sleep(for: .seconds(2.5))
+                    withAnimation {
+                        showViewerLockedToast = false
                     }
+                }
             }
         }
         .animation(.easeInOut(duration: 0.3), value: showViewerLockedToast)


### PR DESCRIPTION
## ✨ PR 유형
- [x] 디자인 수정 (UI 반응형 개선)

<br>

## 🛠️ 작업 내용
- 토스트 상단 여백을 고정값(60pt)에서 `safeAreaPadding(.top, 12)`로 변경하여 기종별 safe area 대응
- `Group` → `HStack(spacing: 0)`으로 변경하여 텍스트 줄바꿈 방지
- `DispatchQueue.main.asyncAfter` → `Task.sleep`으로 교체
- ToastView Preview 추가

<br>

## 🔍 관련 이슈
- closed #108

<br>

## 📸 스크린샷 - UI작업인 경우만 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Toast 컴포넌트에 대한 미리보기 설정 추가

* **Refactor**
  * Toast UI의 레이아웃 및 표시 메커니즘 개선
  * Toast 메시지의 위치 지정 및 애니메이션 타이밍 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DGU-Team404/roomlog-ios/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->