### PR TITLE
[Fix] 백그라운드 전환 시 스캔 폴링 burst 실패 방지

### DIFF
--- a/RoomLog/RoomLog/Features/Home/Data/DTO/RoomDTO.swift
+++ b/RoomLog/RoomLog/Features/Home/Data/DTO/RoomDTO.swift
@@ -44,7 +44,7 @@ struct RoomSummaryDTO: Codable {
     enum CodingKeys: String, CodingKey {
         case roomId = "room_id"
         case name
-        case fileURL = "file_url"
+        case fileURL = "ply_url"
         case latestScan = "latest_scan"
         case recentScanDate = "move_in_date"
         case latestScanStatus = "latest_scan_status"
@@ -88,7 +88,7 @@ struct CreateRoomResponseDTO: Codable {
         case name
         case moveInDate = "move_in_date"
         case moveOutDate = "move_out_date"
-        case fileURL = "file_url"
+        case fileURL = "ply_url"
         case createdAt = "created_at"
         case linkedScan = "linked_scan"
     }
@@ -118,7 +118,7 @@ struct RoomDetailResponseDTO: Codable {
         case name
         case moveInDate = "move_in_date"
         case moveOutDate = "move_out_date"
-        case fileURL = "file_url"
+        case fileURL = "ply_url"
         case createdAt = "created_at"
         case latestScan = "latest_scan"
     }
@@ -175,7 +175,7 @@ struct UpdateRoomResponseDTO: Codable {
         case name
         case moveInDate = "move_in_date"
         case moveOutDate = "move_out_date"
-        case fileURL = "file_url"
+        case fileURL = "ply_url"
     }
 }
 

--- a/RoomLog/RoomLog/Features/Scan/Data/DTO/ScanPreviewResponseDTO.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/DTO/ScanPreviewResponseDTO.swift
@@ -16,7 +16,7 @@ struct ScanPreviewResponseDTO: Codable {
     enum CodingKeys: String, CodingKey {
         case scanId = "scan_id"
         case roomId = "room_id"
-        case fileURL = "file_url"
+        case fileURL = "ply_url"
         case createdAt = "created_at"
     }
 }

--- a/RoomLog/RoomLog/Features/Scan/Data/DTO/ScanResultResponseDTO.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/DTO/ScanResultResponseDTO.swift
@@ -10,21 +10,18 @@ import Foundation
 struct ScanResultResponseDTO: Codable {
     let status: String
     let scanId: Int
-    let fileURL: String
     let createdAt: String
 
     enum CodingKeys: String, CodingKey {
         case status
         case scanId = "scan_id"
-        case fileURL = "file_url"
         case createdAt = "created_at"
     }
 
     func toDomain() -> ScanResult {
         ScanResult(
             scanId: scanId,
-            status: status,
-            fileURL: fileURL
+            status: status
         )
     }
 }

--- a/RoomLog/RoomLog/Features/Scan/Domain/Models/ScanResult.swift
+++ b/RoomLog/RoomLog/Features/Scan/Domain/Models/ScanResult.swift
@@ -10,5 +10,4 @@ import Foundation
 struct ScanResult {
     let scanId: Int
     let status: String
-    let fileURL: String
 }

--- a/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 import ZIPFoundation
 
 @Observable
@@ -43,6 +44,7 @@ final class ScanProcessingManager {
     private var scanRepository: ScanRepositoryProtocol?
     private let fileCache = PLYFileCache.shared
     private var processingTask: Task<Void, Never>?
+    private var isInBackground = false
 
     // MARK: - Setup
 
@@ -118,6 +120,12 @@ final class ScanProcessingManager {
         default:
             return false
         }
+    }
+
+    /// 앱 lifecycle 전환 시 호출
+    @MainActor
+    func handleScenePhase(_ phase: ScenePhase) {
+        isInBackground = (phase != .active)
     }
 
     #if DEBUG
@@ -213,6 +221,12 @@ final class ScanProcessingManager {
         var attempts = 0
         var consecutiveErrors = 0
         while !Task.isCancelled {
+            // 백그라운드 상태에서는 API 호출을 건너뛰고 대기만 한다
+            if isInBackground {
+                try? await Task.sleep(for: .seconds(PollConfig.intervalSeconds))
+                continue
+            }
+
             attempts += 1
             if attempts > PollConfig.maxAttempts {
                 try? await scanRepository.cancelScan(scanId: scanId)

--- a/RoomLog/RoomLog/Features/Tab/Presentation/RoomLogTab.swift
+++ b/RoomLog/RoomLog/Features/Tab/Presentation/RoomLogTab.swift
@@ -16,6 +16,7 @@ struct RoomLogTab: View {
     @State private var showViewerLockedToast: Bool = false
     @Environment(\.di) var di
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.scenePhase) private var scenePhase
 
     private enum TabIdentifier: Hashable {
         case home, viewer, profile
@@ -80,6 +81,9 @@ struct RoomLogTab: View {
             }
         }
         .animation(.easeInOut(duration: 0.3), value: showViewerLockedToast)
+        .onChange(of: scenePhase) { _, newPhase in
+            di.resolve(ScanProcessingManager.self).handleScenePhase(newPhase)
+        }
     }
 }
 

--- a/RoomLog/RoomLog/Utilities/PreviewMocks/PreviewMocks.swift
+++ b/RoomLog/RoomLog/Utilities/PreviewMocks/PreviewMocks.swift
@@ -12,7 +12,7 @@ import Foundation
 
 final class MockScanRepository: ScanRepositoryProtocol {
     func uploadScan(houseId: Int, fileURL: URL) async throws -> ScanResult {
-        ScanResult(scanId: 1, status: "COMPLETED", fileURL: "")
+        ScanResult(scanId: 1, status: "COMPLETED")
     }
 
     func getScanStatus(scanId: Int) async throws -> String {


### PR DESCRIPTION
## ✨ PR 유형
- [x] 버그 수정: 백그라운드 전환 시 스캔 폴링 burst 에러 및 불필요한 DTO 필드 제거

<br>

## 🛠️ 작업 내용
- ScanProcessingManager에 `ScenePhase` 감지 추가, 백그라운드 시 폴링 API 호출 일시정지
- RoomLogTab에서 `scenePhase` 변화를 ScanProcessingManager에 전달
- ScanResultResponseDTO / ScanResult에서 서버에서 삭제된 `fileURL` 필드 제거

<br>

## 🔍 관련 이슈
- closed #110

<br>

## 📸 스크린샷 - UI작업인 경우만 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 스캔 결과 대기 중 앱이 백그라운드로 전환될 때 불필요한 네트워크 폴링을 중지하여 배터리 및 데이터 사용량 개선

* **개선**
  * 내부 API 응답 데이터 구조 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->