### PR TITLE
[Feat] 서버 에러 코드 정의 및 에러 로깅 개선

### DIFF
--- a/RoomLog/RoomLog/Core/Error/RepositoryError.swift
+++ b/RoomLog/RoomLog/Core/Error/RepositoryError.swift
@@ -8,37 +8,55 @@
 import Foundation
 
 enum RepositoryError: Error, LocalizedError, Sendable, Equatable {
-    
-    case serverError(code: Int?, message: String?)
-    
+
+    case serverError(code: Int?, message: String?, errorCode: ServerErrorCode?)
+
     case decodingError(detail: String?)
-    
+
     var errorDescription: String? {
         switch self {
-        case .serverError(_, let message):
+        case .serverError(_, _, let errorCode):
+            // 서버 에러 코드가 있으면 해당 메시지 우선 사용
+            if let errorCode, errorCode != .unknown {
+                return errorCode.userMessage
+            }
             return message ?? "서버 오류가 발생했습니다."
         case .decodingError(let detail):
             return "decoding error: \(detail ?? "unknown detail")"
         }
     }
-    
+
     var code: Int? {
         switch self {
-        case .serverError(let code, _):
+        case .serverError(let code, _, _):
             return code
-        default :
+        default:
             return nil
         }
     }
 
-    var errorCode: String {
-        code.map { String($0) } ?? "unknown code"
+    var message: String? {
+        switch self {
+        case .serverError(_, let message, _):
+            return message
+        default:
+            return nil
+        }
     }
-    
+
+    var serverErrorCode: ServerErrorCode? {
+        switch self {
+        case .serverError(_, _, let errorCode):
+            return errorCode
+        default:
+            return nil
+        }
+    }
+
     var userMessage: String {
-        errorDescription ?? "unknown error"
+        errorDescription ?? "알 수 없는 오류가 발생했습니다."
     }
-    
+
     var isRetryable: Bool {
         switch self {
         case .serverError:

--- a/RoomLog/RoomLog/Core/Error/ServerErrorCode.swift
+++ b/RoomLog/RoomLog/Core/Error/ServerErrorCode.swift
@@ -1,0 +1,114 @@
+//
+//  ServerErrorCode.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/2/26.
+//
+
+import Foundation
+
+enum ServerErrorCode: String, Sendable {
+    // MARK: - Common
+    case commonBadRequest = "COMMON_400"
+    case commonUnauthorized = "COMMON_401"
+    case commonForbidden = "COMMON_403"
+    case commonNotFound = "COMMON_404"
+    case commonServerError = "COMMON_500"
+
+    // MARK: - Auth
+    case authInvalidCredentials = "AUTH_001"
+    case authDuplicateEmail = "AUTH_002"
+    case authUserNotFound = "AUTH_005"
+    case authInvalidToken = "AUTH_006"
+
+    // MARK: - Room
+    case roomNotFound = "ROOM_001"
+    case roomAccessDenied = "ROOM_002"
+
+    // MARK: - Scan
+    case scanNotFound = "SCAN_001"
+    case scanNotCompleted = "SCAN_004"
+
+    // MARK: - Analysis
+    case analysisNotFound = "ANALYSIS_001"
+    case analysisAlreadyProcessed = "ANALYSIS_002"
+    case analysisInvalidScanPair = "ANALYSIS_003"
+    case analysisNotCompleted = "ANALYSIS_004"
+
+    // MARK: - Defect
+    case defectNotFound = "DEFECT_001"
+
+    // MARK: - Estimate
+    case estimateCreateFailed = "ESTIMATE_001"
+    case estimateNotFound = "ESTIMATE_002"
+    case estimateAccessDenied = "ESTIMATE_003"
+
+    // MARK: - Repair
+    case repairNotFound = "REPAIR_001"
+
+    // MARK: - RepairShop
+    case repairShopNotAvailable = "REPAIRSHOP_001"
+    case repairShopNotFound = "REPAIRSHOP_002"
+
+    case unknown
+
+    init(rawValue: String) {
+        switch rawValue {
+        case "COMMON_400": self = .commonBadRequest
+        case "COMMON_401": self = .commonUnauthorized
+        case "COMMON_403": self = .commonForbidden
+        case "COMMON_404": self = .commonNotFound
+        case "COMMON_500": self = .commonServerError
+        case "AUTH_001": self = .authInvalidCredentials
+        case "AUTH_002": self = .authDuplicateEmail
+        case "AUTH_005": self = .authUserNotFound
+        case "AUTH_006": self = .authInvalidToken
+        case "ROOM_001": self = .roomNotFound
+        case "ROOM_002": self = .roomAccessDenied
+        case "SCAN_001": self = .scanNotFound
+        case "SCAN_004": self = .scanNotCompleted
+        case "ANALYSIS_001": self = .analysisNotFound
+        case "ANALYSIS_002": self = .analysisAlreadyProcessed
+        case "ANALYSIS_003": self = .analysisInvalidScanPair
+        case "ANALYSIS_004": self = .analysisNotCompleted
+        case "DEFECT_001": self = .defectNotFound
+        case "ESTIMATE_001": self = .estimateCreateFailed
+        case "ESTIMATE_002": self = .estimateNotFound
+        case "ESTIMATE_003": self = .estimateAccessDenied
+        case "REPAIR_001": self = .repairNotFound
+        case "REPAIRSHOP_001": self = .repairShopNotAvailable
+        case "REPAIRSHOP_002": self = .repairShopNotFound
+        default: self = .unknown
+        }
+    }
+
+    var userMessage: String {
+        switch self {
+        case .commonBadRequest: return "잘못된 요청입니다."
+        case .commonUnauthorized: return "인증이 필요합니다."
+        case .commonForbidden: return "접근 권한이 없습니다."
+        case .commonNotFound: return "요청한 데이터를 찾을 수 없습니다."
+        case .commonServerError: return "서버 내부 오류가 발생했습니다."
+        case .authInvalidCredentials: return "이메일 또는 비밀번호가 올바르지 않습니다."
+        case .authDuplicateEmail: return "이미 가입된 이메일입니다."
+        case .authUserNotFound: return "사용자를 찾을 수 없습니다."
+        case .authInvalidToken: return "만료되었거나 유효하지 않은 토큰입니다."
+        case .roomNotFound: return "존재하지 않는 방입니다."
+        case .roomAccessDenied: return "해당 방에 접근 권한이 없습니다."
+        case .scanNotFound: return "존재하지 않는 스캔입니다."
+        case .scanNotCompleted: return "스캔이 아직 완료되지 않았습니다."
+        case .analysisNotFound: return "분석 결과가 존재하지 않습니다."
+        case .analysisAlreadyProcessed: return "이미 처리된 분석입니다."
+        case .analysisInvalidScanPair: return "선택한 스캔 조합이 올바르지 않거나 비교 가능한 스캔이 부족합니다."
+        case .analysisNotCompleted: return "분석이 아직 완료되지 않았습니다."
+        case .defectNotFound: return "존재하지 않는 하자 정보입니다."
+        case .estimateCreateFailed: return "견적 요청 생성에 실패했습니다."
+        case .estimateNotFound: return "존재하지 않는 견적 요청입니다."
+        case .estimateAccessDenied: return "해당 견적 요청에 접근 권한이 없습니다."
+        case .repairNotFound: return "존재하지 않는 수리 내역입니다."
+        case .repairShopNotAvailable: return "추천 가능한 수리 업체가 없습니다."
+        case .repairShopNotFound: return "업체 정보를 찾을 수 없습니다."
+        case .unknown: return "알 수 없는 오류가 발생했습니다."
+        }
+    }
+}

--- a/RoomLog/RoomLog/Core/NetworkAdapter/Base/APIResponse.swift
+++ b/RoomLog/RoomLog/Core/NetworkAdapter/Base/APIResponse.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct APIResponse<T: Codable>: Codable {
     // MARK: - Property
-    
+
     /// 요청 성공 여부
     let isSuccess: Bool
     /// 응답 코드
@@ -18,31 +18,40 @@ struct APIResponse<T: Codable>: Codable {
     let message: String?
     /// 응답 결과
     let result: T?
-    
-    
+    /// 에러 정보
+    let error: APIErrorBody?
+
+
     private enum CodingKeys: String, CodingKey {
         case isSuccess = "success"
         case code
         case message
         case result = "data"
+        case error
     }
+}
+
+struct APIErrorBody: Codable {
+    let code: String?
 }
 
 extension APIResponse {
     func unwrap() throws -> T {
+        let errorCode = error?.code.map { ServerErrorCode(rawValue: $0) }
+
         guard isSuccess else {
-            throw RepositoryError.serverError(code: code, message: message)
+            throw RepositoryError.serverError(code: code, message: message, errorCode: errorCode)
         }
-        
+
         if let result {
             return result
         }
-        
+
         if T.self == EmptyResult.self, let empty = EmptyResult() as? T {
             return empty
         }
-        
-        throw RepositoryError.serverError(code: code, message: message)
+
+        throw RepositoryError.serverError(code: code, message: message, errorCode: errorCode)
     }
 }
 

--- a/RoomLog/RoomLog/Core/NetworkAdapter/TokenRefreshService/MoyaNetworkAdapter.swift
+++ b/RoomLog/RoomLog/Core/NetworkAdapter/TokenRefreshService/MoyaNetworkAdapter.swift
@@ -79,6 +79,20 @@ extension MoyaNetworkAdapter {
         let status = response.statusCode
         let icon = (200..<300).contains(status) ? "🟢" : "🔴"
         print("\(icon) [Network] ← \(status) \(method) \(url)")
+
+        // 에러 응답이면 서버 에러 코드 파싱
+        if !(200..<300).contains(status) {
+            if let errorInfo = try? JSONDecoder().decode(APIErrorResponse.self, from: data) {
+                let code = errorInfo.error?.code ?? "없음"
+                let message = errorInfo.message ?? ""
+                let serverError = ServerErrorCode(rawValue: code)
+                print("  ⚠️ [\(code)] \(serverError.userMessage)")
+                if !message.isEmpty {
+                    print("  💬 서버 메시지: \(message)")
+                }
+            }
+        }
+
         if let str = String(data: data, encoding: .utf8) {
             let preview = str.prefix(500)
             print("  📄 Response: \(preview)\(str.count > 500 ? "..." : "")")
@@ -211,6 +225,17 @@ extension MoyaNetworkAdapter {
         parameters: [String: Any]
     ) throws -> URLRequest {
         try URLEncoding.queryString.encode(request, with: parameters)
+    }
+}
+
+// MARK: - Error Response (로깅용)
+
+private struct APIErrorResponse: Codable {
+    let message: String?
+    let error: ErrorBody?
+
+    struct ErrorBody: Codable {
+        let code: String?
     }
 }
 

--- a/RoomLog/RoomLog/Features/Estimate/Data/Repositories/EstimateRepository.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Data/Repositories/EstimateRepository.swift
@@ -69,7 +69,7 @@ final class EstimateRepository: EstimateRepositoryProtocol {
             response = try await adapter.request(EstimateTarget.previewEstimate(request: body))
         } catch {
             let nsError = error as NSError
-            throw RepositoryError.serverError(code: nsError.code, message: nsError.localizedDescription)
+            throw RepositoryError.serverError(code: nsError.code, message: nsError.localizedDescription, errorCode: nil)
         }
         let apiResponse: APIResponse<EstimatePreviewResponseDTO>
         do {
@@ -86,7 +86,7 @@ final class EstimateRepository: EstimateRepositoryProtocol {
             response = try await adapter.request(EstimateTarget.getEstimateDetail(estimateId: estimateId))
         } catch {
             let nsError = error as NSError
-            throw RepositoryError.serverError(code: nsError.code, message: nsError.localizedDescription)
+            throw RepositoryError.serverError(code: nsError.code, message: nsError.localizedDescription, errorCode: nil)
         }
         let apiResponse: APIResponse<EstimateDetailResponseDTO>
         do {


### PR DESCRIPTION
## ✨ PR 유형
- [x] <!-- 변경 사항 작성 -->새로운 기능 추가 

<br>

## 🛠️ 작업 내용
- ServerErrorCode enum 추가 (COMMON, AUTH, ROOM, SCAN, ANALYSIS 등 전체 에러 코드 매핑)
- APIResponse에 error 필드 추가하여 서버 에러 코드 파싱
- RepositoryError에 errorCode 파라미터 추가, 한글 사용자 메시지 우선 표시
- 네트워크 에러 로그에 서버 에러 코드 + 사용자 메시지 출력


<br>

## 🔍 관련 이슈
- closed #114 

<br>

## 📸 스크린샷 - UI작업인 경우만 추가
