### PR TITLE
[Feat] 스캔 및 홈 UX 개선

### DIFF
--- a/RoomLog/RoomLog/Features/Home/Presentation/Components/ZoomableScrollView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Components/ZoomableScrollView.swift
@@ -98,6 +98,7 @@ struct ZoomableScrollView<Content: View>: UIViewControllerRepresentable {
         scrollView.backgroundColor = .clear
         scrollView.contentSize = contentSize
         scrollView.decelerationRate = .fast
+        scrollView.scrollsToTop = false
 
         let hostingController = UIHostingController(rootView: content())
         hostingController.view.backgroundColor = .clear
@@ -189,8 +190,17 @@ struct ZoomableScrollView<Content: View>: UIViewControllerRepresentable {
     }
 }
 
+/// `setContentOffset(_:animated:)` 형태의 외부 트리거(탭바 재탭 등)에 의한 자동 스크롤을 무시한다.
+/// 내부 코드에서는 `contentOffset = ...` 형태(animated: false)로만 설정하므로 정상 동작에 영향이 없다.
+final class NonAnimatedSetOffsetScrollView: UIScrollView {
+    override func setContentOffset(_ contentOffset: CGPoint, animated: Bool) {
+        if animated { return }
+        super.setContentOffset(contentOffset, animated: animated)
+    }
+}
+
 final class ZoomableScrollViewController: UIViewController {
-    let scrollView = UIScrollView()
+    let scrollView = NonAnimatedSetOffsetScrollView()
 
     override func loadView() {
         view = scrollView

--- a/RoomLog/RoomLog/Features/Home/Presentation/ViewModels/HomeState.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/ViewModels/HomeState.swift
@@ -12,4 +12,5 @@ import Observation
 final class HomeState {
     var hasHouses: Bool = false
     var selectedHouse: House?
+    var recenterMapTrigger: Int = 0
 }

--- a/RoomLog/RoomLog/Features/Home/Presentation/Views/HomeView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Views/HomeView.swift
@@ -27,7 +27,12 @@ struct HomeView: View {
     }
 
     var body: some View {
-        HouseMapView(houses: viewModel.houses, mainHouseId: viewModel.mainHouse?.houseId, namespace: houseNamespace) { house in
+        HouseMapView(
+            houses: viewModel.houses,
+            mainHouseId: viewModel.mainHouse?.houseId,
+            namespace: houseNamespace,
+            recenterTrigger: homeState.recenterMapTrigger
+        ) { house in
             homeState.selectedHouse = house
             pathStore.homePath.append(.home(.roomList(houseId: house.houseId, houseName: house.name)))
         }

--- a/RoomLog/RoomLog/Features/Home/Presentation/Views/HouseMapView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Views/HouseMapView.swift
@@ -35,12 +35,14 @@ struct HouseMapView: View {
     let houses: [House]
     var mainHouseId: Int?
     var namespace: Namespace.ID
+    var recenterTrigger: Int = 0
     var onHouseTap: (House) -> Void
 
     @State private var viewModel = HouseMapViewModel()
     @State private var isScrollEnabled: Bool = true
     @State private var scrollProxy = ScrollProxy()
     @State private var autoScrollTimer: Timer?
+    @State private var hasCenteredOnce: Bool = false
 
     // MARK: - Body
 
@@ -100,9 +102,24 @@ struct HouseMapView: View {
             }
             .ignoresSafeArea()
             .onAppear {
-                scrollToCenter()
+                if !hasCenteredOnce {
+                    scrollToCenter()
+                    hasCenteredOnce = true
+                }
             }
-            .onChange(of: houses) {
+            .onChange(of: houses) { oldHouses, newHouses in
+                if newHouses.count > oldHouses.count {
+                    let oldIds = Set(oldHouses.map { $0.houseId })
+                    guard let added = newHouses.first(where: { !oldIds.contains($0.houseId) }),
+                          let index = newHouses.firstIndex(where: { $0.houseId == added.houseId }) else {
+                        return
+                    }
+                    scrollToCenter(target: viewModel.positionFor(house: added, index: index))
+                } else if newHouses.count < oldHouses.count {
+                    scrollToCenter()
+                }
+            }
+            .onChange(of: recenterTrigger) {
                 scrollToCenter()
             }
             .onDisappear {
@@ -131,10 +148,10 @@ struct HouseMapView: View {
 
     // MARK: - Scroll
 
-    private func scrollToCenter() {
-        let target = viewModel.centerTarget(houses: houses, mainHouseId: mainHouseId)
+    private func scrollToCenter(target: CGPoint? = nil) {
+        let point = target ?? viewModel.centerTarget(houses: houses, mainHouseId: mainHouseId)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            scrollProxy.scrollTo(canvasPoint: target)
+            scrollProxy.scrollTo(canvasPoint: point)
         }
     }
 

--- a/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
@@ -187,6 +187,7 @@ final class ScanProcessingManager {
             scanResult = try await scanRepository.uploadScan(houseId: houseId, fileURL: zipURL)
         } catch {
             cleanup(zipURL: zipURL, datasetDir: datasetDir)
+            if Task.isCancelled { return }
             activeScan = ActiveScan(scanId: 0, houseId: houseId, phase: .failed("업로드 실패: \(error.localizedDescription)"))
             return
         }

--- a/RoomLog/RoomLog/Features/Scan/Presentation/Views/ScanView.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/Views/ScanView.swift
@@ -43,6 +43,7 @@ struct ScanView: View {
     var body: some View {
         scanPhase
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar(.hidden, for: .tabBar)
             .onAppear { viewModel.setup() }
             .onDisappear { viewModel.tearDown() }
             .onChange(of: viewModel.phase) {

--- a/RoomLog/RoomLog/Features/Tab/Presentation/RoomLogTab.swift
+++ b/RoomLog/RoomLog/Features/Tab/Presentation/RoomLogTab.swift
@@ -28,7 +28,17 @@ struct RoomLogTab: View {
         let homeState = di.resolve(HomeState.self)
         let _ = di.resolve(ScanProcessingManager.self)
 
-        TabView(selection: $selectedTab) {
+        let tabSelection = Binding<TabIdentifier>(
+            get: { selectedTab },
+            set: { newValue in
+                if newValue == .home && selectedTab == .home {
+                    homeState.recenterMapTrigger += 1
+                }
+                selectedTab = newValue
+            }
+        )
+
+        TabView(selection: tabSelection) {
             Tab("Home", systemImage: "house", value: .home) {
                 NavigationStack(path: Bindable(pathStore).homePath) {
                     HomeView(provider: di.resolve(HomeUseCaseProvider.self))


### PR DESCRIPTION
## ✨ PR 유형
- [x] 기능 추가 (feat)
- [x] 버그 수정 (fix)

<br>

## 🛠️ 작업 내용
- **ScanView 진입 시 탭바 숨김**: `.toolbar(.hidden, for: .tabBar)` 적용으로 3D 스캔 화면에서 탭바 비표시
- **스캔 업로드 중 취소 시 실패 상태로 표시되는 문제 수정**: 업로드 `catch` 블록에 `Task.isCancelled` 가드 추가. 취소된 경우 `.failed` 상태로 덮어쓰지 않고 즉시 반환하여 "3D 스캔하기" 버튼으로 자연스럽게 복귀
- **탭바 재탭 시 홈 맵이 자동 스크롤되는 문제 수정**: iOS의 `setContentOffset(_:animated:)` 호출을 무시하는 `NonAnimatedSetOffsetScrollView` 서브클래스를 도입. 내부 코드는 모두 `contentOffset` 직접 할당(animated: false)이라 정상 기능에 영향 없음
- **홈 맵 포커싱 정책 개선**
  - `hasCenteredOnce` 플래그로 앱 첫 진입 시에만 mainHouse 포커싱
  - RoomList 다녀오기 / 다른 탭 전환 후 복귀 시 위치 유지
  - 홈 탭 재탭 시 `HomeState.recenterMapTrigger`를 증가시켜 mainHouse로 포커싱
  - 집 추가 시 추가된 집 좌표로 스크롤, 집 삭제 시 mainHouse로 스크롤
  - `scrollToCenter(target:)`로 리팩토링하여 목표 좌표를 명시적으로 받도록 개선

<br>

## 🔍 관련 이슈
- closed #117

<br>

## 📸 스크린샷 - UI작업인 경우만 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 홈 탭을 재선택하여 지도를 손쉽게 재중앙화할 수 있습니다.

* **버그 수정**
  * 상태 표시줄 탭 시 발생하는 원치 않는 자동 스크롤 동작을 해결했습니다.
  * 스캔 중 하단 탭 바를 숨겨 더 나은 화면 표시를 제공합니다.
  * 업로드 취소 시 상태 처리를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->