### PR TITLE
[Refactor] 코드 현대화 및 UX 개선

### DIFF
--- a/RoomLog/RoomLog.xcodeproj/project.pbxproj
+++ b/RoomLog/RoomLog.xcodeproj/project.pbxproj
@@ -372,7 +372,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -412,7 +412,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/RoomLog/RoomLog.xcodeproj/project.pbxproj
+++ b/RoomLog/RoomLog.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0BAC0D0E2FCF31680067B330 /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = 0BAC0D0D2FCF31680067B330 /* Nuke */; };
+		0BAC0D102FCF31680067B330 /* NukeUI in Frameworks */ = {isa = PBXBuildFile; productRef = 0BAC0D0F2FCF31680067B330 /* NukeUI */; };
 		0BC1FE092F8BCDCF00B9AA18 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 0BC1FE082F8BCDCF00B9AA18 /* ZIPFoundation */; };
 		0BEFDD972F84FDF900CDE2A6 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 0BEFDD962F84FDF900CDE2A6 /* Moya */; };
 		DBF07F762FB4230E00708069 /* KakaoMapsSDK-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = DBF07F752FB4230E00708069 /* KakaoMapsSDK-SPM */; };
@@ -59,9 +61,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0BAC0D102FCF31680067B330 /* NukeUI in Frameworks */,
 				0BEFDD972F84FDF900CDE2A6 /* Moya in Frameworks */,
 				0BC1FE092F8BCDCF00B9AA18 /* ZIPFoundation in Frameworks */,
 				DBF07F762FB4230E00708069 /* KakaoMapsSDK-SPM in Frameworks */,
+				0BAC0D0E2FCF31680067B330 /* Nuke in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -117,6 +121,8 @@
 				0BEFDD962F84FDF900CDE2A6 /* Moya */,
 				0BC1FE082F8BCDCF00B9AA18 /* ZIPFoundation */,
 				DBF07F752FB4230E00708069 /* KakaoMapsSDK-SPM */,
+				0BAC0D0D2FCF31680067B330 /* Nuke */,
+				0BAC0D0F2FCF31680067B330 /* NukeUI */,
 			);
 			productName = RoomLog;
 			productReference = 0B1EC4402F7BB970001FE02F /* RoomLog.app */;
@@ -177,6 +183,7 @@
 				0BEFDD952F84FDF900CDE2A6 /* XCRemoteSwiftPackageReference "Moya" */,
 				0BC1FE072F8BCDCF00B9AA18 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
 				DBF07F742FB4230E00708069 /* XCRemoteSwiftPackageReference "KakaoMapsSDK-SPM" */,
+				0BAC0D0C2FCF31680067B330 /* XCRemoteSwiftPackageReference "Nuke" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 0B1EC4412F7BB970001FE02F /* Products */;
@@ -512,6 +519,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		0BAC0D0C2FCF31680067B330 /* XCRemoteSwiftPackageReference "Nuke" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kean/Nuke";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 13.0.6;
+			};
+		};
 		0BC1FE072F8BCDCF00B9AA18 /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/weichsel/ZIPFoundation";
@@ -539,6 +554,16 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		0BAC0D0D2FCF31680067B330 /* Nuke */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0BAC0D0C2FCF31680067B330 /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = Nuke;
+		};
+		0BAC0D0F2FCF31680067B330 /* NukeUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0BAC0D0C2FCF31680067B330 /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = NukeUI;
+		};
 		0BC1FE082F8BCDCF00B9AA18 /* ZIPFoundation */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0BC1FE072F8BCDCF00B9AA18 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;

--- a/RoomLog/RoomLog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RoomLog/RoomLog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a99561ac9356da28fe4d27496c616fc4cf885772919c8805069a2951ebcf29b3",
+  "originHash" : "82ec2b0643d740c74b7434c125db4ce937f5a44af9b7583b3273446ebe2fe2b6",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "c263811c1f3dbf002be9bd83107f7cdc38992b26",
         "version" : "15.0.3"
+      }
+    },
+    {
+      "identity" : "nuke",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Nuke",
+      "state" : {
+        "revision" : "63a8fcbd6621340a2410bc3e9575ac97058615f4",
+        "version" : "13.0.6"
       }
     },
     {

--- a/RoomLog/RoomLog/Core/Common/UIComponents/DefectReportRow.swift
+++ b/RoomLog/RoomLog/Core/Common/UIComponents/DefectReportRow.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import NukeUI
 
 struct DefectReportRow: View {
     let defect: DefectReportDetail
@@ -15,11 +16,10 @@ struct DefectReportRow: View {
             // 하자 이미지 썸네일
             Group {
                 if let urlString = defect.imageURL, let url = URL(string: urlString) {
-                    AsyncImage(url: url) { phase in
-                        switch phase {
-                        case .success(let image):
+                    LazyImage(url: url) { state in
+                        if let image = state.image {
                             image.resizable().aspectRatio(contentMode: .fill)
-                        default:
+                        } else {
                             thumbnailPlaceholder
                         }
                     }

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonSelectView.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonSelectView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import NukeUI
 
 struct ComparisonSelectView: View {
     @Environment(\.di) var di
@@ -161,8 +162,8 @@ struct ScanSelectionRow: View {
     private var thumbnailView: some View {
         Group {
             if let urlString = scan.thumbnailURL, let url = URL(string: urlString) {
-                AsyncImage(url: url) { phase in
-                    if case .success(let image) = phase {
+                LazyImage(url: url) { state in
+                    if let image = state.image {
                         image.resizable().aspectRatio(contentMode: .fill)
                     } else {
                         placeholder

--- a/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectDetailView.swift
+++ b/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectDetailView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import NukeUI
 
 struct DefectDetailView: View {
     let defect: DefectReportDetail
@@ -47,22 +48,19 @@ private extension DefectDetailView {
         Group {
             if let urlString = defect.imageURL ?? roomImageURL,
                let url = URL(string: urlString) {
-                AsyncImage(url: url) { phase in
-                    switch phase {
-                    case .success(let image):
+                LazyImage(url: url) { state in
+                    if let image = state.image {
                         image.resizable().aspectRatio(contentMode: .fill)
-                    case .failure:
+                    } else if state.error != nil {
                         imagePlaceholder
                             .overlay {
                                 Text("이미지를 불러올 수 없습니다")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
                             }
-                    case .empty:
+                    } else {
                         ProgressView()
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    @unknown default:
-                        imagePlaceholder
                     }
                 }
             } else {

--- a/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectListView.swift
+++ b/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectListView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import NukeUI
 
 struct DefectListView: View {
     @Environment(\.di) var di
@@ -77,8 +78,8 @@ private struct DefectListRow: View {
     private var thumbnailView: some View {
         Group {
             if let urlString = item.thumbnailURL, let url = URL(string: urlString) {
-                AsyncImage(url: url) { phase in
-                    if case .success(let image) = phase {
+                LazyImage(url: url) { state in
+                    if let image = state.image {
                         image.resizable().aspectRatio(contentMode: .fill)
                     } else {
                         placeholder

--- a/RoomLog/RoomLog/Features/Estimate/Presentation/Views/RepairHistoryView.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Presentation/Views/RepairHistoryView.swift
@@ -66,10 +66,9 @@ struct RepairHistoryView: View {
                 }
                 .padding(.top, 8)
                 .transition(.move(edge: .top).combined(with: .opacity))
-                .onAppear {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                        withAnimation { viewModel.showSuccessToast = false }
-                    }
+                .task {
+                    try? await Task.sleep(for: .seconds(2))
+                    withAnimation { viewModel.showSuccessToast = false }
                 }
             }
         }

--- a/RoomLog/RoomLog/Features/Estimate/Presentation/Views/RepairShopListView.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Presentation/Views/RepairShopListView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import NukeUI
 
 struct RepairShopListView: View {
     @Environment(\.di) var di
@@ -304,13 +305,12 @@ private struct ShopCard: View {
     }
 
     private var shopImage: some View {
-        AsyncImage(url: URL(string: shop.imageURL ?? "")) { phase in
-            switch phase {
-            case .success(let image):
+        LazyImage(url: URL(string: shop.imageURL ?? "")) { state in
+            if let image = state.image {
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
-            default:
+            } else {
                 Color.blueGray50
                     .overlay(
                         Image(systemName: "photo")

--- a/RoomLog/RoomLog/Features/Home/Data/DTO/RoomDTO.swift
+++ b/RoomLog/RoomLog/Features/Home/Data/DTO/RoomDTO.swift
@@ -44,7 +44,7 @@ struct RoomSummaryDTO: Codable {
     enum CodingKeys: String, CodingKey {
         case roomId = "room_id"
         case name
-        case fileURL = "ply_url"
+        case fileURL = "thumbnail_url"
         case latestScan = "latest_scan"
         case recentScanDate = "move_in_date"
         case latestScanStatus = "latest_scan_status"

--- a/RoomLog/RoomLog/Features/Home/Presentation/Components/ZoomableScrollView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Components/ZoomableScrollView.swift
@@ -125,7 +125,7 @@ struct ZoomableScrollView<Content: View>: UIViewControllerRepresentable {
 
         // 이전 스크롤 위치가 있으면 복원
         if let saved = scrollProxy?.lastOffset {
-            DispatchQueue.main.async {
+            Task {
                 scrollView.contentOffset = saved
             }
         }

--- a/RoomLog/RoomLog/Features/Home/Presentation/Views/HouseListView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Views/HouseListView.swift
@@ -125,10 +125,9 @@ struct HouseListView: View {
             if viewModel.showSetMainSuccess {
                 successToast
                     .transition(.move(edge: .top).combined(with: .opacity))
-                    .onAppear {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                            withAnimation { viewModel.showSetMainSuccess = false }
-                        }
+                    .task {
+                        try? await Task.sleep(for: .seconds(2))
+                        withAnimation { viewModel.showSetMainSuccess = false }
                     }
             }
         }

--- a/RoomLog/RoomLog/Features/Home/Presentation/Views/HouseMapView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Views/HouseMapView.swift
@@ -150,7 +150,8 @@ struct HouseMapView: View {
 
     private func scrollToCenter(target: CGPoint? = nil) {
         let point = target ?? viewModel.centerTarget(houses: houses, mainHouseId: mainHouseId)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        Task {
+            try? await Task.sleep(for: .seconds(0.1))
             scrollProxy.scrollTo(canvasPoint: point)
         }
     }
@@ -181,9 +182,7 @@ struct HouseMapView: View {
             let dy = -edgeRatio(topDist) * maxSpeed + edgeRatio(bottomDist) * maxSpeed
 
             if abs(dx) > 0.1 || abs(dy) > 0.1 {
-                DispatchQueue.main.async {
-                    scrollProxy.adjustOffset(by: CGVector(dx: dx, dy: dy))
-                }
+                scrollProxy.adjustOffset(by: CGVector(dx: dx, dy: dy))
             }
         }
     }

--- a/RoomLog/RoomLog/Features/Home/Presentation/Views/RoomListView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Views/RoomListView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import NukeUI
 
 struct RoomListView: View {
 
@@ -186,13 +187,12 @@ struct RoomListView: View {
     @ViewBuilder
     private func thumbnailView(url: String?) -> some View {
         if let urlString = url, let imageURL = URL(string: urlString) {
-            AsyncImage(url: imageURL) { phase in
-                switch phase {
-                case .success(let image):
+            LazyImage(url: imageURL) { state in
+                if let image = state.image {
                     image
                         .resizable()
                         .aspectRatio(contentMode: .fill)
-                default:
+                } else {
                     thumbnailPlaceholder
                 }
             }

--- a/RoomLog/RoomLog/Features/Home/Presentation/Views/RoomListView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Views/RoomListView.swift
@@ -290,7 +290,10 @@ struct RoomListView: View {
             onDismiss: {
                 processingManager.cancel()
                 showProcessingStatus = false
-            }
+            },
+            onRetry: processingManager.canRetryUpload ? {
+                processingManager.retryUpload()
+            } : nil
         )
     }
 

--- a/RoomLog/RoomLog/Features/Home/Presentation/Views/Sheets/ScanStatusSheet.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Views/Sheets/ScanStatusSheet.swift
@@ -13,6 +13,7 @@ struct ScanStatusSheet: View {
     var onPreview: ((URL) -> Void)?
     var onCancel: (() -> Void)?
     var onDismiss: (() -> Void)?
+    var onRetry: (() -> Void)?
 
     @State private var showCancelAlert: Bool = false
 
@@ -126,11 +127,26 @@ struct ScanStatusSheet: View {
             .glassEffect(.regular.interactive().tint(.accent), in: .capsule)
             .padding(.horizontal, 32)
         case .failed:
-            Button {
-                onDismiss?()
-            } label: {
-                Text("닫기")
-                    .font(.semibold, 16)
+            VStack(spacing: 12) {
+                if let onRetry {
+                    Button {
+                        onRetry()
+                    } label: {
+                        Text("다시 시도")
+                            .font(.semibold, 16)
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 50)
+                    }
+                    .glassEffect(.regular.interactive().tint(.accent), in: .capsule)
+                    .padding(.horizontal, 32)
+                }
+                Button {
+                    onDismiss?()
+                } label: {
+                    Text("닫기")
+                        .font(.semibold, 16)
+                }
             }
         }
     }

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
@@ -47,7 +47,7 @@ final class VideoEncoder: @unchecked Sendable {
                 return
             }
             spinCount += 1
-            try? await Task.sleep(nanoseconds: 10_000_000)
+            try? await Task.sleep(for: .milliseconds(10))
         }
         encode(frame: frame)
     }
@@ -106,14 +106,10 @@ final class VideoEncoder: @unchecked Sendable {
             return
         }
         videoWriterInput?.markAsFinished()
-        await withCheckedContinuation { continuation in
-            writer.finishWriting { [weak self] in
-                if self?.videoWriter?.status == .failed { self?.status = .error }
-                self?.videoWriter = nil
-                self?.videoWriterInput = nil
-                self?.videoAdapter = nil
-                continuation.resume()
-            }
-        }
+        await writer.finishWriting()
+        if writer.status == .failed { status = .error }
+        videoWriter = nil
+        videoWriterInput = nil
+        videoAdapter = nil
     }
 }

--- a/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
@@ -28,6 +28,13 @@ final class ScanProcessingManager {
         let phase: ProcessingPhase
     }
 
+    /// 업로드 실패 후 재시도용 zip과 그 소유 houseId를 함께 보관.
+    /// 다른 집의 새 스캔이 시작돼도 cross-house 업로드가 일어나지 않도록 한 단위로 묶는다.
+    private struct PendingRetry {
+        let houseId: Int
+        let zipURL: URL
+    }
+
     // MARK: - Persistence Keys
 
     private enum Defaults {
@@ -38,8 +45,8 @@ final class ScanProcessingManager {
     // MARK: - State
 
     private(set) var activeScan: ActiveScan?
-    /// 업로드 실패 후 재시도용 zip 파일. nil이면 재시도 불가.
-    private var pendingRetryZipURL: URL?
+    /// 업로드 실패 후 재시도용 정보. nil이면 재시도 불가.
+    private var pendingRetry: PendingRetry?
 
     // MARK: - Dependencies
 
@@ -103,16 +110,23 @@ final class ScanProcessingManager {
         discardPendingRetry()
     }
 
-    /// 업로드 실패 후 사용 가능한 재시도 여부
+    /// 업로드 실패 후 사용 가능한 재시도 여부.
+    /// `activeScan`이 `.failed` 상태이고 보관된 retry의 houseId가 일치할 때만 true.
     @MainActor
-    var canRetryUpload: Bool { pendingRetryZipURL != nil }
+    var canRetryUpload: Bool {
+        guard let pendingRetry, let activeScan else { return false }
+        guard case .failed = activeScan.phase else { return false }
+        return activeScan.houseId == pendingRetry.houseId
+    }
 
     /// 업로드 실패 후 동일한 zip으로 업로드 재시도
     @MainActor
     func retryUpload() {
-        guard let zipURL = pendingRetryZipURL,
-              let scan = activeScan else { return }
-        let houseId = scan.houseId
+        guard let pendingRetry,
+              let scan = activeScan,
+              scan.houseId == pendingRetry.houseId else { return }
+        let houseId = pendingRetry.houseId
+        let zipURL = pendingRetry.zipURL
         processingTask?.cancel()
         activeScan = ActiveScan(scanId: 0, houseId: houseId, phase: .uploading)
         processingTask = Task { [weak self] in
@@ -213,7 +227,7 @@ final class ScanProcessingManager {
             }
             // 재시도 가능하도록 zip은 보존하고 datasetDir만 정리
             try? FileManager.default.removeItem(at: datasetDir)
-            pendingRetryZipURL = zipURL
+            pendingRetry = PendingRetry(houseId: houseId, zipURL: zipURL)
             activeScan = ActiveScan(scanId: 0, houseId: houseId, phase: .failed("업로드 실패: \(error.localizedDescription)"))
             return
         }
@@ -234,9 +248,9 @@ final class ScanProcessingManager {
 
     @MainActor
     private func discardPendingRetry() {
-        if let zipURL = pendingRetryZipURL {
-            try? FileManager.default.removeItem(at: zipURL)
-            pendingRetryZipURL = nil
+        if let pendingRetry {
+            try? FileManager.default.removeItem(at: pendingRetry.zipURL)
+            self.pendingRetry = nil
         }
     }
 
@@ -254,7 +268,7 @@ final class ScanProcessingManager {
             return
         }
         try? FileManager.default.removeItem(at: zipURL)
-        pendingRetryZipURL = nil
+        pendingRetry = nil
         if Task.isCancelled { return }
 
         let scanId = scanResult.scanId

--- a/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
@@ -38,6 +38,8 @@ final class ScanProcessingManager {
     // MARK: - State
 
     private(set) var activeScan: ActiveScan?
+    /// 업로드 실패 후 재시도용 zip 파일. nil이면 재시도 불가.
+    private var pendingRetryZipURL: URL?
 
     // MARK: - Dependencies
 
@@ -83,6 +85,7 @@ final class ScanProcessingManager {
         processingTask?.cancel()
         activeScan = nil
         clearPendingScan()
+        discardPendingRetry()
 
         if scanId > 0 {
             Task { [weak self] in
@@ -97,6 +100,24 @@ final class ScanProcessingManager {
         processingTask?.cancel()
         activeScan = nil
         clearPendingScan()
+        discardPendingRetry()
+    }
+
+    /// 업로드 실패 후 사용 가능한 재시도 여부
+    @MainActor
+    var canRetryUpload: Bool { pendingRetryZipURL != nil }
+
+    /// 업로드 실패 후 동일한 zip으로 업로드 재시도
+    @MainActor
+    func retryUpload() {
+        guard let zipURL = pendingRetryZipURL,
+              let scan = activeScan else { return }
+        let houseId = scan.houseId
+        processingTask?.cancel()
+        activeScan = ActiveScan(scanId: 0, houseId: houseId, phase: .uploading)
+        processingTask = Task { [weak self] in
+            await self?.retryUploadProcess(zipURL: zipURL, houseId: houseId)
+        }
     }
 
     /// 특정 houseId에 완료된 스캔이 있는지 확인
@@ -186,8 +207,13 @@ final class ScanProcessingManager {
         do {
             scanResult = try await scanRepository.uploadScan(houseId: houseId, fileURL: zipURL)
         } catch {
-            cleanup(zipURL: zipURL, datasetDir: datasetDir)
-            if Task.isCancelled { return }
+            if Task.isCancelled {
+                cleanup(zipURL: zipURL, datasetDir: datasetDir)
+                return
+            }
+            // 재시도 가능하도록 zip은 보존하고 datasetDir만 정리
+            try? FileManager.default.removeItem(at: datasetDir)
+            pendingRetryZipURL = zipURL
             activeScan = ActiveScan(scanId: 0, houseId: houseId, phase: .failed("업로드 실패: \(error.localizedDescription)"))
             return
         }
@@ -204,6 +230,37 @@ final class ScanProcessingManager {
     private func cleanup(zipURL: URL, datasetDir: URL) {
         try? FileManager.default.removeItem(at: zipURL)
         try? FileManager.default.removeItem(at: datasetDir)
+    }
+
+    @MainActor
+    private func discardPendingRetry() {
+        if let zipURL = pendingRetryZipURL {
+            try? FileManager.default.removeItem(at: zipURL)
+            pendingRetryZipURL = nil
+        }
+    }
+
+    // MARK: - Retry
+
+    @MainActor
+    private func retryUploadProcess(zipURL: URL, houseId: Int) async {
+        guard let scanRepository else { return }
+        let scanResult: ScanResult
+        do {
+            scanResult = try await scanRepository.uploadScan(houseId: houseId, fileURL: zipURL)
+        } catch {
+            if Task.isCancelled { return }
+            activeScan = ActiveScan(scanId: 0, houseId: houseId, phase: .failed("업로드 실패: \(error.localizedDescription)"))
+            return
+        }
+        try? FileManager.default.removeItem(at: zipURL)
+        pendingRetryZipURL = nil
+        if Task.isCancelled { return }
+
+        let scanId = scanResult.scanId
+        savePendingScan(scanId: scanId, houseId: houseId)
+        activeScan = ActiveScan(scanId: scanId, houseId: houseId, phase: .polling)
+        await pollAndDownload(scanId: scanId, houseId: houseId)
     }
 
     // MARK: - Poll & Download

--- a/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
@@ -68,6 +68,7 @@ final class ScanProcessingManager {
     @MainActor
     func startFullProcess(encoder: DatasetEncoder, houseId: Int) {
         processingTask?.cancel()
+        discardPendingRetry()
         activeScan = ActiveScan(scanId: 0, houseId: houseId, phase: .zipping)
         processingTask = Task { [weak self] in
             await self?.fullProcess(encoder: encoder, houseId: houseId)

--- a/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerView.swift
+++ b/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import NukeUI
 
 struct ViewerView: View {
     @Environment(\.di) var di
@@ -241,8 +242,8 @@ private struct RecentRoomRow: View {
     private var thumbnailView: some View {
         Group {
             if let urlString = room.thumbnailURL, let url = URL(string: urlString) {
-                AsyncImage(url: url) { phase in
-                    if case .success(let image) = phase {
+                LazyImage(url: url) { state in
+                    if let image = state.image {
                         image.resizable().aspectRatio(contentMode: .fill)
                     } else {
                         placeholder


### PR DESCRIPTION
## ✨ PR 유형
- [x] 리팩토링 (refactor)
- [x] 기능 추가 (feat)
- [x] 기타 작업 (chore)

<br>

## 🛠️ 작업 내용

### 동시성 패턴 정리
- `DispatchQueue.main.async` / `asyncAfter` 5곳을 SwiftUI `.task` / `Task { ... }` / 인라인 처리로 교체. 뷰 lifecycle에 묶여 자동 취소
- `AVAssetWriter`의 `withCheckedContinuation` 래퍼 제거 → iOS 18+ async API `await writer.finishWriting()` 직접 호출
- `Task.sleep(nanoseconds:)` → `Task.sleep(for: .milliseconds(...))`
- 프로젝트가 `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`로 설정되어 있어 `Task { @MainActor in }`의 명시적 어노테이션은 redundant → 제거

### iPhone 세로모드 고정
- `project.pbxproj`의 `INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone`를 Portrait 단일로 변경

### 스캔 업로드 실패 시 재시도
- `ScanProcessingManager`에 `pendingRetryZipURL`을 추가해 업로드 실패 시 zip은 보존하고 datasetDir만 정리
- `canRetryUpload` computed property와 `retryUpload()` 메서드 추가 (동일 zip으로 업로드만 재시도)
- `ScanStatusSheet`에 `onRetry` 콜백 추가, `.failed` 상태에서 `다시 시도` + `닫기` 두 버튼 노출
- `RoomListView`에서 `processingManager.canRetryUpload`일 때만 retry 콜백 전달 (압축 실패 등 비재시도성 실패는 미노출)

### 이미지 로딩 현대화
- `NukeUI` SPM 의존성 추가
- 프로젝트 전반 `AsyncImage` → `NukeUI.LazyImage` 일괄 교체 (총 7개 뷰)
  - `DefectReportRow`, `RoomListView`, `DefectListView`, `DefectDetailView`, `ViewerView`, `ComparisonSelectView`, `RepairShopListView`
- 메모리/디스크 캐싱 자동 처리되어 스크롤 시 재로드/깜빡임 제거

### API 연동
- `RoomDTO.RoomSummaryDTO.fileURL`의 CodingKey를 `ply_url` → `thumbnail_url`로 변경하여 룸 썸네일 이미지 URL 수신

<br>

## 🔍 관련 이슈
- closed #119

<br>

## 📸 스크린샷 - UI작업인 경우만 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 스캔 업로드 재시도 기능 추가 및 실패 시 UI에 “다시 시도” 버튼 제공

* **개선 사항**
  * 이미지 로딩 엔진 교체로 표시 안정성·성능 향상 (썸네일/상세/목록 등)
  * 성공 알림의 애니메이션 및 자동 해제 개선
  * 화면 스크롤 위치 복원 및 자동 스크롤 동작 최적화
  * iPhone 세로(Portrait) 단일 방향 지원으로 화면 구성 일관화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->