### PR TITLE
[Refactor] Scan/Home 파트 코드 정리

### DIFF
--- a/RoomLog/RoomLog/Features/Home/Presentation/Components/PLYSceneView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Components/PLYSceneView.swift
@@ -58,7 +58,9 @@ struct PLYSceneView: UIViewRepresentable {
         for defect in defects {
             guard !defect.region3d.isEmpty else { continue }
             let points = defect.region3d
+            #if DEBUG
             print("[PLY] defect \(defect.id): \(points.count) points")
+            #endif
 
             // 1. 파란색 영역 — 꼭짓점을 순서대로 이어 polygon
             let regionNode = createPolygonNode(points: points)

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/ConfidenceEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/ConfidenceEncoder.swift
@@ -21,7 +21,9 @@ final class ConfidenceEncoder {
         do {
             try FileManager.default.createDirectory(at: outDirectory, withIntermediateDirectories: true)
         } catch {
+            #if DEBUG
             print("ConfidenceEncoder: 디렉토리 생성 실패. \(error.localizedDescription)")
+            #endif
             status = .encodingError
         }
     }
@@ -42,7 +44,9 @@ final class ConfidenceEncoder {
         do {
             try ciContext.writePNGRepresentation(of: image, to: framePath, format: .L8, colorSpace: colorSpace)
         } catch {
+            #if DEBUG
             print("ConfidenceEncoder: PNG 저장 실패 (frame \(frameNumber)). \(error.localizedDescription)")
+            #endif
             status = .encodingError
         }
     }

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/DatasetEncoder.swift
@@ -136,7 +136,9 @@ final class DatasetEncoder {
         do {
             try imuEncoder.done()
         } catch {
+            #if DEBUG
             print("DatasetEncoder: IMU 파일 닫기 실패. \(error.localizedDescription)")
+            #endif
             status = .videoEncodingError
         }
 
@@ -168,14 +170,16 @@ final class DatasetEncoder {
         do {
             try csv.write(to: cameraMatrixPath, atomically: true, encoding: .utf8)
         } catch {
+            #if DEBUG
             print("DatasetEncoder: could not write camera matrix. \(error.localizedDescription)")
+            #endif
             status = .videoEncodingError
         }
     }
 
     private static func createDirectory(id: inout UUID) throws -> URL {
         let directoryName = hashUUID(id: id)
-        let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let documentsURL = URL.documentsDirectory
         let directory = documentsURL.appendingPathComponent(directoryName, isDirectory: true)
 
         if FileManager.default.fileExists(atPath: directory.path) {

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/DepthEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/DepthEncoder.swift
@@ -20,7 +20,9 @@ final class DepthEncoder {
         do {
             try FileManager.default.createDirectory(at: outDirectory, withIntermediateDirectories: true)
         } catch {
+            #if DEBUG
             print("DepthEncoder: 디렉토리 생성 실패. \(error.localizedDescription)")
+            #endif
             status = .frameEncodingError
         }
     }
@@ -41,7 +43,9 @@ final class DepthEncoder {
         defer { CVPixelBufferUnlockBaseAddress(frame, .readOnly) }
 
         guard let baseAddress = CVPixelBufferGetBaseAddress(frame) else {
+            #if DEBUG
             print("DepthEncoder: base address 접근 실패 (frame \(frameNumber))")
+            #endif
             status = .frameEncodingError
             return
         }
@@ -83,7 +87,9 @@ final class DepthEncoder {
         }
 
         if !success {
+            #if DEBUG
             print("DepthEncoder: PNG 저장 실패 (frame \(frameNumber))")
+            #endif
             status = .frameEncodingError
         }
     }

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/OdometryEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/OdometryEncoder.swift
@@ -35,7 +35,9 @@ final class OdometryEncoder {
         do {
             try fileHandle.close()
         } catch {
+            #if DEBUG
             print("OdometryEncoder: 파일 닫기 실패. \(error.localizedDescription)")
+            #endif
         }
     }
 }

--- a/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
+++ b/RoomLog/RoomLog/Features/Scan/Data/Encoders/VideoEncoder.swift
@@ -83,7 +83,9 @@ final class VideoEncoder: @unchecked Sendable {
             writer.startWriting()
             writer.startSession(atSourceTime: .zero)
         } catch {
+            #if DEBUG
             print("VideoEncoder: AVAssetWriter 생성 실패. \(error.localizedDescription)")
+            #endif
             status = .error
         }
     }
@@ -93,7 +95,9 @@ final class VideoEncoder: @unchecked Sendable {
         if firstFrameTime == nil { firstFrameTime = frame.time }
         let time = CMTime(seconds: frame.time - anchor, preferredTimescale: timeScale)
         if videoAdapter?.append(frame.buffer, withPresentationTime: time) == false {
+            #if DEBUG
             print("VideoEncoder: pixel buffer append 실패.")
+            #endif
             status = .error
         }
     }
@@ -101,7 +105,9 @@ final class VideoEncoder: @unchecked Sendable {
     private func doneRecording() async {
         guard let writer = videoWriter else { return }
         guard writer.status != .failed else {
+            #if DEBUG
             print("VideoEncoder: 인코딩 중 오류 발생.")
+            #endif
             status = .error
             return
         }

--- a/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanProcessingManager.swift
@@ -311,7 +311,9 @@ final class ScanProcessingManager {
             do {
                 let status = try await scanRepository.getScanStatus(scanId: scanId).uppercased()
                 consecutiveErrors = 0
+                #if DEBUG
                 print("[ScanProcessing] scanId=\(scanId) status=\(status)")
+                #endif
                 if status == "COMPLETED" {
                     break
                 } else if status == "FAILED" {

--- a/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanViewModel.swift
+++ b/RoomLog/RoomLog/Features/Scan/Presentation/ViewModels/ScanViewModel.swift
@@ -89,7 +89,9 @@ final class ScanViewModel: NSObject {
         do {
             encoder = try DatasetEncoder(arConfiguration: configuration)
         } catch {
+            #if DEBUG
             print("ScanViewModel: 인코더 사전 준비 실패. \(error.localizedDescription)")
+            #endif
         }
     }
 


### PR DESCRIPTION
## ✨ PR 유형
- [x] 리팩토링 (refactor)
- [x] 기타 작업 (chore)

<br>

## 🛠️ 작업 내용

### 디버그 print 가드 (13곳, 8개 파일)
- 다음 `print()` 호출들이 `#if DEBUG` 없이 노출되어 있어 release 빌드에 디버그 로그가 그대로 출력됨 → 모두 `#if DEBUG` 블록으로 감싸기
  - `ScanProcessingManager.swift:314` — 폴링 상태 로그
  - `ScanViewModel.swift:92` — 인코더 사전 준비 실패
  - `PLYSceneView.swift:61` — 하자 포인트 카운트
  - Scan 인코더 6개 파일 — 디렉토리/파일 생성·저장 실패 로그 (Confidence/Dataset×2/Depth×3/Odometry/Video×3)

### `DatasetEncoder` 강제 언래핑 제거
- `FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!` (`DatasetEncoder.swift:178`)는 실제로는 안전하지만 표현이 불명확
- iOS 16+의 비옵셔널 API `URL.documentsDirectory`로 교체 (deployment target iOS 26+이라 호환)

<br>

## 🔍 관련 이슈
- closed #121

<br>

## 📸 스크린샷 - UI작업인 경우만 추가