### PR TITLE
[Feat] 내방비교 API 연동(입주 전/후)

### DIFF
--- a/RoomLog/RoomLog/Core/DIContainer/DIContainer.swift
+++ b/RoomLog/RoomLog/Core/DIContainer/DIContainer.swift
@@ -108,17 +108,12 @@ extension DIContainer {
         }
 
         container.register(ComparisonUseCaseProvider.self) {
-            ComparisonUseCaseProviderImpl(repository: container.resolve(ComparisonRepositoryProtocol.self))
+            ComparisonUseCaseProviderImpl(adapter: container.resolve(MoyaNetworkAdapter.self))
         }
 
         // MARK: - Repository
         container.register(DefectRepositoryProtocol.self) {
             DefectRepository(adapter: container.resolve(MoyaNetworkAdapter.self))
-        }
-        
-        // TODO: 서버 연동 시 ComparisonRepository(adapter:)로 교체
-        container.register(ComparisonRepositoryProtocol.self) {
-            MockComparisonRepository()
         }
 
         // MARK: - Scan Processing

--- a/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
@@ -33,7 +33,7 @@ enum NavigationDestination: Hashable {
         
         /// 내방비교 case
         case comparisonSelect
-        case comparisonResult(moveInScanId: Int, moveOutScanId: Int)
+        case comparisonResult(moveInRoomId: Int, moveOutRoomId: Int)
     }
     
     enum MyPage: Hashable {

--- a/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
@@ -84,8 +84,12 @@ private extension NavigationRoutingView {
             RepairHistoryView(roomId: roomId, provider: di.resolve(EstimateUseCaseProvider.self))
         case .comparisonSelect:
             ComparisonSelectView(provider: di.resolve(ComparisonUseCaseProvider.self))
-        case .comparisonResult(let moveInScanId, let moveOutScanId):
-            ComparisonResultView(moveInScanId: moveInScanId, moveOutScanId: moveOutScanId)
+        case .comparisonResult(let moveInRoomId, let moveOutRoomId):
+            ComparisonResultView(
+                moveInRoomId: moveInRoomId,
+                moveOutRoomId: moveOutRoomId,
+                provider: di.resolve(DefectUseCaseProvider.self)
+            )
         }
     }
     

--- a/RoomLog/RoomLog/Features/Comparison/Data/Repositories/ComparisonRepository.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Data/Repositories/ComparisonRepository.swift
@@ -1,0 +1,48 @@
+//
+//  ComparisonRepository.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/3/26.
+//
+
+import Foundation
+import Moya
+
+final class ComparisonRepository: ComparisonRepositoryProtocol {
+    private let adapter: MoyaNetworkAdapter
+    private let decoder: JSONDecoder
+
+    init(adapter: MoyaNetworkAdapter, decoder: JSONDecoder = JSONDecoder()) {
+        self.adapter = adapter
+        self.decoder = decoder
+    }
+
+    func getHouses() async throws -> [House] {
+        let response = try await adapter.request(HouseTarget.getHouses)
+        let apiResponse: APIResponse<GetHousesResponseDTO>
+        do {
+            apiResponse = try decoder.decode(APIResponse<GetHousesResponseDTO>.self, from: response.data)
+        } catch {
+            throw RepositoryError.decodingError(detail: error.localizedDescription)
+        }
+        return try apiResponse.unwrap().houses.map { $0.toDomain() }
+    }
+
+    func getRooms(houseId: Int) async throws -> [ComparisonScan] {
+        let response = try await adapter.request(HouseTarget.getHouseRooms(houseId: houseId))
+        let apiResponse: APIResponse<GetHouseRoomsResponseDTO>
+        do {
+            apiResponse = try decoder.decode(APIResponse<GetHouseRoomsResponseDTO>.self, from: response.data)
+        } catch {
+            throw RepositoryError.decodingError(detail: error.localizedDescription)
+        }
+        return try apiResponse.unwrap().rooms.map { dto in
+            ComparisonScan(
+                id: dto.roomId,
+                roomName: dto.name,
+                scanDate: dto.recentScanDate.flatMap { Date.fromServerDate($0) },
+                thumbnailURL: dto.fileURL
+            )
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Comparison/Data/Repositories/MockComparisonRepository.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Data/Repositories/MockComparisonRepository.swift
@@ -8,14 +8,18 @@
 import Foundation
 
 final class MockComparisonRepository: ComparisonRepositoryProtocol {
-    func getScans() async throws -> [ComparisonScan] {
+    func getHouses() async throws -> [House] {
         [
-            ComparisonScan(id: 1, roomName: "망고의 방", scanDate: Date(timeIntervalSinceNow: -86400 * 90), thumbnailURL: nil, scanType: .moveIn),
-            ComparisonScan(id: 2, roomName: "민교의 방", scanDate: Date(timeIntervalSinceNow: -86400 * 60), thumbnailURL: nil, scanType: .moveIn),
-            ComparisonScan(id: 3, roomName: "밍교의 방", scanDate: Date(timeIntervalSinceNow: -86400 * 45), thumbnailURL: nil, scanType: .moveIn),
-            ComparisonScan(id: 4, roomName: "망고의 방", scanDate: Date(timeIntervalSinceNow: -86400 * 3), thumbnailURL: nil, scanType: .moveOut),
-            ComparisonScan(id: 5, roomName: "민교의 방", scanDate: Date(timeIntervalSinceNow: -86400 * 1), thumbnailURL: nil, scanType: .moveOut),
-            ComparisonScan(id: 6, roomName: "밍교의 방", scanDate: Date(timeIntervalSinceNow: -86400 * 7), thumbnailURL: nil, scanType: .moveOut),
+            House(houseId: 1, name: "망고의 집", address: "서울시 중구"),
+            House(houseId: 2, name: "민교의 집", address: "서울시 강남구")
+        ]
+    }
+
+    func getRooms(houseId: Int) async throws -> [ComparisonScan] {
+        [
+            ComparisonScan(id: 1, roomName: "거실", scanDate: Date(timeIntervalSinceNow: -86400 * 90), thumbnailURL: nil),
+            ComparisonScan(id: 2, roomName: "안방", scanDate: Date(timeIntervalSinceNow: -86400 * 60), thumbnailURL: nil),
+            ComparisonScan(id: 3, roomName: "주방", scanDate: Date(timeIntervalSinceNow: -86400 * 45), thumbnailURL: nil)
         ]
     }
 }

--- a/RoomLog/RoomLog/Features/Comparison/Domain/Interfaces/ComparisonRepositoryProtocol.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Domain/Interfaces/ComparisonRepositoryProtocol.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 protocol ComparisonRepositoryProtocol {
-    /// 방 스캔 목록 조회
-    func getScans() async throws -> [ComparisonScan]
+    /// 집 목록 조회
+    func getHouses() async throws -> [House]
+    /// 집의 방 목록 조회
+    func getRooms(houseId: Int) async throws -> [ComparisonScan]
 }

--- a/RoomLog/RoomLog/Features/Comparison/Domain/Models/ComparisonScan.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Domain/Models/ComparisonScan.swift
@@ -10,12 +10,6 @@ import Foundation
 struct ComparisonScan: Hashable, Identifiable {
     let id: Int
     let roomName: String
-    let scanDate: Date
+    let scanDate: Date?
     let thumbnailURL: String?
-    let scanType: ScanType // "IN" or "OUT"
-}
-
-public enum ScanType: String, Codable {
-    case moveIn = "IN"
-    case moveOut = "OUT"
 }

--- a/RoomLog/RoomLog/Features/Comparison/Domain/UseCases/GetComparisonScansUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Domain/UseCases/GetComparisonScansUseCaseProtocol.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
-protocol GetComparisonScansUseCaseProtocol {
-    func execute() async throws -> [ComparisonScan]
+protocol GetComparisonHousesUseCaseProtocol {
+    func execute() async throws -> [House]
+}
+
+protocol GetComparisonRoomsUseCaseProtocol {
+    func execute(houseId: Int) async throws -> [ComparisonScan]
 }

--- a/RoomLog/RoomLog/Features/Comparison/Domain/UseCases/Implementations/GetComparisonScansUseCase.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Domain/UseCases/Implementations/GetComparisonScansUseCase.swift
@@ -7,14 +7,26 @@
 
 import Foundation
 
-final class GetComparisonScansUseCase: GetComparisonScansUseCaseProtocol {
+final class GetComparisonHousesUseCase: GetComparisonHousesUseCaseProtocol {
     private let repository: ComparisonRepositoryProtocol
 
     init(repository: ComparisonRepositoryProtocol) {
         self.repository = repository
     }
 
-    func execute() async throws -> [ComparisonScan] {
-        try await repository.getScans()
+    func execute() async throws -> [House] {
+        try await repository.getHouses()
+    }
+}
+
+final class GetComparisonRoomsUseCase: GetComparisonRoomsUseCaseProtocol {
+    private let repository: ComparisonRepositoryProtocol
+
+    init(repository: ComparisonRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(houseId: Int) async throws -> [ComparisonScan] {
+        try await repository.getRooms(houseId: houseId)
     }
 }

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/Provider/ComparisonUseCaseProvider.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/Provider/ComparisonUseCaseProvider.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 protocol ComparisonUseCaseProvider {
-    func makeGetComparisonScansUseCase() -> GetComparisonScansUseCaseProtocol
+    func makeGetComparisonHousesUseCase() -> GetComparisonHousesUseCaseProtocol
+    func makeGetComparisonRoomsUseCase() -> GetComparisonRoomsUseCaseProtocol
 }
 
 final class ComparisonUseCaseProviderImpl: ComparisonUseCaseProvider {
@@ -18,7 +19,15 @@ final class ComparisonUseCaseProviderImpl: ComparisonUseCaseProvider {
         self.repository = repository
     }
 
-    func makeGetComparisonScansUseCase() -> GetComparisonScansUseCaseProtocol {
-        GetComparisonScansUseCase(repository: repository)
+    init(adapter: MoyaNetworkAdapter) {
+        self.repository = ComparisonRepository(adapter: adapter)
+    }
+
+    func makeGetComparisonHousesUseCase() -> GetComparisonHousesUseCaseProtocol {
+        GetComparisonHousesUseCase(repository: repository)
+    }
+
+    func makeGetComparisonRoomsUseCase() -> GetComparisonRoomsUseCaseProtocol {
+        GetComparisonRoomsUseCase(repository: repository)
     }
 }

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonResultView.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonResultView.swift
@@ -8,91 +8,234 @@
 import SwiftUI
 
 struct ComparisonResultView: View {
-    let moveInScanId: Int
-    let moveOutScanId: Int
+    @Environment(\.di) var di
+    @State private var viewModel: ComparisonResultViewModel
+
+    init(moveInRoomId: Int, moveOutRoomId: Int, provider: DefectUseCaseProvider) {
+        self._viewModel = .init(
+            wrappedValue: ComparisonResultViewModel(
+                moveInRoomId: moveInRoomId,
+                moveOutRoomId: moveOutRoomId,
+                provider: provider
+            )
+        )
+    }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                imagePlaceholder
-                differenceSection
+        Group {
+            switch viewModel.phase {
+            case .loading:
+                ProgressView()
+            case .polling:
+                pollingContent
+            case .completed:
+                if let result = viewModel.result {
+                    completedContent(result: result)
+                }
+            case .failed(let message):
+                errorView(message: message)
             }
-            .padding(.horizontal, 16)
-            .padding(.top, 8)
-            .padding(.bottom, 24)
         }
         .navigationTitle("비교 결과")
         .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await viewModel.loadOrAnalyze()
+        }
     }
 }
 
-// MARK: - Image Placeholder
+// MARK: - Polling Content
 
 private extension ComparisonResultView {
-    var imagePlaceholder: some View {
-        ZStack {
-            Color.blueGray50
-                .overlay {
-                    VStack(spacing: 8) {
-                        Image(systemName: "cube.transparent")
-                            .font(.system(size: 40))
-                            .foregroundStyle(Color.blueGray300)
-                        Text("3D 모델 영역")
-                            .font(.medium, 14)
-                            .foregroundStyle(Color.blueGray300)
-                    }
-                }
+    var pollingContent: some View {
+        AnalysisLoadingView(message: "AI가 입주 전/후를 비교하고 있습니다...") {
+            plySection(defects: [])
+        }
+    }
+}
 
-            GeometryReader { geo in
-                ForEach(PreviewSampleData.defects.prefix(3), id: \.id) { defect in
-                    if let x = defect.x, let y = defect.y {
-                        VStack(spacing: 2) {
-                            Text(defect.type.displayName)
-                                .font(.semibold, 12)
-                            Text(String(format: "%.2f m²", defect.defectArea))
-                                .font(.medium, 11)
-                        }
-                        .foregroundStyle(Color.neutral800)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(.white.opacity(0.9), in: RoundedRectangle(cornerRadius: 8))
-                        .position(
-                            x: CGFloat(x) * geo.size.width,
-                            y: CGFloat(y) * geo.size.height
-                        )
-                    }
-                }
+// MARK: - Completed Content
+
+private extension ComparisonResultView {
+    func completedContent(result: AnalysisResult) -> some View {
+        let pathStore = di.resolve(PathStore.self)
+        return ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                plySection(defects: result.defects)
+                summarySection(result: result)
+                defectListSection(result: result, pathStore: pathStore)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+            .padding(.bottom, 16)
+        }
+        .safeAreaInset(edge: .bottom) {
+            BottomCTAButton {
+                pathStore.defectPath.append(.defect(.repairHistory(roomId: result.roomId)))
+            } label: {
+                Text("수리 내역 보기")
+                    .font(.semibold, 17)
             }
         }
-        .frame(maxWidth: .infinity)
-        .aspectRatio(16 / 10, contentMode: .fit)
-        .clipShape(RoundedRectangle(cornerRadius: 16))
     }
 }
 
-// MARK: - Difference Section
+// MARK: - 3D PLY Viewer
 
 private extension ComparisonResultView {
-    var differenceSection: some View {
+    func plySection(defects: [DefectReportDetail]) -> some View {
+        Group {
+            if let localURL = viewModel.plyLocalURL {
+                PLYSceneView(fileURL: localURL, defects: defects)
+            } else if viewModel.result?.plyURL != nil {
+                ProgressView("3D 모델 로딩 중...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ImagePlaceholder(iconFont: .largeTitle)
+            }
+        }
+        .aspectRatio(3/4, contentMode: .fit)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .task {
+            await viewModel.downloadPLYIfNeeded()
+        }
+    }
+}
+
+// MARK: - Summary
+
+private extension ComparisonResultView {
+    func summarySection(result: AnalysisResult) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("내 RoomLog 정보")
+                .font(.semibold, 13)
+                .foregroundStyle(Color.blueGray500)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 4)
+                .background(Color.blueGray50, in: RoundedRectangle(cornerRadius: 20))
+
+            Spacer().frame(height: 16)
+
+            HStack(spacing: 0) {
+                SummaryStatView(value: "\(result.defectCount)", label: "하자")
+                SummaryStatView(value: formattedCost(result.totalCost), label: "예상 수리비")
+                SummaryStatView(value: String(format: "%.1fm²", result.totalArea), label: "면적")
+            }
+
+            Spacer().frame(height: 16)
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 10)
+        .frame(maxWidth: .infinity)
+        .background(.white, in: RoundedRectangle(cornerRadius: 20))
+        .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 2)
+    }
+
+    func formattedCost(_ cost: Int) -> String {
+        let manWon = cost / 10000
+        if manWon > 0 { return "\(manWon)만원" }
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        return "\(f.string(from: NSNumber(value: cost)) ?? "\(cost)")원"
+    }
+}
+
+// MARK: - Defect List
+
+private extension ComparisonResultView {
+    func defectListSection(result: AnalysisResult, pathStore: PathStore) -> some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 8) {
-                Text("주요 차이점")
+            HStack {
+                Text("감지된 하자")
                     .font(.semibold, 20)
                     .foregroundStyle(Color.neutral800)
-                Text("\(PreviewSampleData.defects.count)")
-                    .font(.semibold, 20)
-                    .foregroundStyle(Color.accentColor)
+                Spacer()
+                Button {
+                    pathStore.defectPath.append(.defect(.defectAllList(
+                        roomId: result.roomId,
+                        roomName: "",
+                        defects: result.defects
+                    )))
+                } label: {
+                    HStack(spacing: 4) {
+                        Text("전체보기")
+                            .font(.semibold, 14)
+                        Image(systemName: "chevron.right")
+                            .font(.semibold, 11)
+                    }
+                    .foregroundStyle(Color.mutedBlue)
+                }
             }
 
-            ForEach(PreviewSampleData.defects, id: \.id) { defect in
+            ForEach(result.defects, id: \.id) { defect in
                 DefectReportRow(defect: defect)
+                    .onTapGesture {
+                        pathStore.defectPath.append(.defect(.defectListDetail(
+                            defect: defect,
+                            roomId: result.roomId,
+                            roomImageURL: result.plyURL
+                        )))
+                    }
             }
         }
+    }
+}
+
+// MARK: - Error View
+
+private extension ComparisonResultView {
+    func errorView(message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(Color.blueGray300)
+            Text("비교 분석에 실패했습니다")
+                .font(.semibold, 18)
+                .foregroundStyle(Color.neutral800)
+            Text(message)
+                .font(.medium, 14)
+                .foregroundStyle(Color.blueGray400)
+                .multilineTextAlignment(.center)
+            Button {
+                Task { await viewModel.startAnalysis() }
+            } label: {
+                Text("다시 시도")
+                    .font(.semibold, 16)
+                    .foregroundStyle(Color.accentColor)
+            }
+        }
+        .padding(32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Summary Stat 
+
+private struct SummaryStatView: View {
+    let value: String
+    let label: String
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text(value)
+                .font(.semibold, 24)
+                .foregroundStyle(.primary)
+            Text(label)
+                .font(.medium, 16)
+                .foregroundStyle(Color.dustyBlue)
+        }
+        .frame(maxWidth: .infinity)
     }
 }
 
 #Preview {
+    let di = DIContainer.configured()
     NavigationStack {
-        ComparisonResultView(moveInScanId: 1, moveOutScanId: 4)
+        ComparisonResultView(
+            moveInRoomId: 1,
+            moveOutRoomId: 2,
+            provider: di.resolve(DefectUseCaseProvider.self)
+        )
     }
+    .environment(\.di, di)
 }

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonResultView.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonResultView.swift
@@ -197,7 +197,7 @@ private extension ComparisonResultView {
                 .foregroundStyle(Color.blueGray400)
                 .multilineTextAlignment(.center)
             Button {
-                Task { await viewModel.startAnalysis() }
+                Task { await viewModel.loadOrAnalyze() }
             } label: {
                 Text("다시 시도")
                     .font(.semibold, 16)

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonSelectView.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonSelectView.swift
@@ -10,7 +10,11 @@ import SwiftUI
 struct ComparisonSelectView: View {
     @Environment(\.di) var di
     @State private var viewModel: ComparisonViewModel
-    @State private var scanType: ScanType = .moveIn
+    @State private var step: SelectionStep = .moveIn
+
+    enum SelectionStep {
+        case moveIn, moveOut
+    }
 
     init(provider: ComparisonUseCaseProvider) {
         self._viewModel = .init(
@@ -21,6 +25,11 @@ struct ComparisonSelectView: View {
     var body: some View {
         let pathStore = di.resolve(PathStore.self)
         VStack(spacing: 0) {
+            // 집 선택
+            if !viewModel.houses.isEmpty {
+                houseSelector
+            }
+
             stepIndicator
                 .padding(.vertical, 16)
 
@@ -33,7 +42,35 @@ struct ComparisonSelectView: View {
         .navigationTitle("비교할 방 선택")
         .navigationBarTitleDisplayMode(.inline)
         .task {
-            await viewModel.fetchScans()
+            await viewModel.fetchHouses()
+        }
+    }
+}
+
+// MARK: - House Selector
+
+private extension ComparisonSelectView {
+    var houseSelector: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(viewModel.houses) { house in
+                    Button {
+                        viewModel.selectHouse(house)
+                    } label: {
+                        Text(house.name)
+                            .font(.medium, 14)
+                            .foregroundStyle(viewModel.selectedHouse?.id == house.id ? .white : Color.neutral800)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .background(
+                                viewModel.selectedHouse?.id == house.id ? Color.mutedBlue : Color.blueGray50,
+                                in: Capsule()
+                            )
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
         }
     }
 }
@@ -43,8 +80,8 @@ struct ComparisonSelectView: View {
 private extension ComparisonSelectView {
     var stepIndicator: some View {
         HStack(spacing: 24) {
-            stepLabel(number: 1, title: "입주 방 선택", isActive: scanType == .moveIn)
-            stepLabel(number: 2, title: "퇴거 방 선택", isActive: scanType == .moveOut)
+            stepLabel(number: 1, title: "입주 전 방 선택", isActive: step == .moveIn)
+            stepLabel(number: 2, title: "퇴거 후 방 선택", isActive: step == .moveOut)
         }
     }
 
@@ -65,32 +102,38 @@ private extension ComparisonSelectView {
 // MARK: - Scan List
 
 private extension ComparisonSelectView {
-    var currentScans: [ComparisonScan] {
-        scanType == .moveIn ? viewModel.moveInScans : viewModel.moveOutScans
-    }
-
     var selectedScan: ComparisonScan? {
-        scanType == .moveIn ? viewModel.selectedMoveInScan : viewModel.selectedMoveOutScan
+        step == .moveIn ? viewModel.selectedMoveInScan : viewModel.selectedMoveOutScan
     }
 
     var scanList: some View {
         ScrollView {
-            LazyVStack(spacing: 12) {
-                ForEach(currentScans) { scan in
-                    ScanSelectionRow(
-                        scan: scan,
-                        isSelected: selectedScan?.id == scan.id
-                    )
-                    .onTapGesture {
-                        if scanType == .moveIn {
-                            viewModel.selectedMoveInScan = scan
-                        } else {
-                            viewModel.selectedMoveOutScan = scan
+            if viewModel.isLoading {
+                ProgressView()
+                    .padding(.top, 40)
+            } else if viewModel.rooms.isEmpty {
+                Text("방이 없습니다")
+                    .font(.medium, 16)
+                    .foregroundStyle(Color.blueGray300)
+                    .padding(.top, 40)
+            } else {
+                LazyVStack(spacing: 12) {
+                    ForEach(viewModel.rooms) { scan in
+                        ScanSelectionRow(
+                            scan: scan,
+                            isSelected: selectedScan?.id == scan.id
+                        )
+                        .onTapGesture {
+                            if step == .moveIn {
+                                viewModel.selectedMoveInScan = scan
+                            } else {
+                                viewModel.selectedMoveOutScan = scan
+                            }
                         }
                     }
                 }
+                .padding(.horizontal, 16)
             }
-            .padding(.horizontal, 16)
         }
     }
 }
@@ -100,20 +143,24 @@ private extension ComparisonSelectView {
 private extension ComparisonSelectView {
     @ViewBuilder
     func bottomButton(pathStore: PathStore) -> some View {
-        let isEnabled = (scanType == .moveIn && viewModel.selectedMoveInScan != nil)
-            || (scanType == .moveOut && viewModel.selectedMoveOutScan != nil)
+        let isEnabled = (step == .moveIn && viewModel.selectedMoveInScan != nil)
+            || (step == .moveOut && viewModel.selectedMoveOutScan != nil)
 
         BottomCTAButton {
-            if scanType == .moveIn {
-                scanType = .moveOut
+            if step == .moveIn {
+                print("[Comparison] step: moveIn → moveOut, selected: \(viewModel.selectedMoveInScan?.roomName ?? "nil")")
+                step = .moveOut
             } else if let moveIn = viewModel.selectedMoveInScan,
                       let moveOut = viewModel.selectedMoveOutScan {
+                print("[Comparison] 방 비교하기 — moveIn: \(moveIn.id)(\(moveIn.roomName)), moveOut: \(moveOut.id)(\(moveOut.roomName))")
                 pathStore.defectPath.append(
-                    .defect(.comparisonResult(moveInScanId: moveIn.id, moveOutScanId: moveOut.id))
+                    .defect(.comparisonResult(moveInRoomId: moveIn.id, moveOutRoomId: moveOut.id))
                 )
+            } else {
+                print("[Comparison] 방 비교하기 실패 — moveIn: \(viewModel.selectedMoveInScan?.id as Any), moveOut: \(viewModel.selectedMoveOutScan?.id as Any)")
             }
         } label: {
-            Text(scanType == .moveIn ? "다음" : "방 비교하기")
+            Text(step == .moveIn ? "다음" : "방 비교하기")
                 .font(.semibold, 17)
         }
         .opacity(isEnabled ? 1 : 0.5)
@@ -134,15 +181,16 @@ struct ScanSelectionRow: View {
                 Text(scan.roomName)
                     .font(.semibold, 16)
                     .foregroundStyle(Color.neutral800)
-                Text(scan.scanDate.toShortDisplayString())
-                    .font(.medium, 14)
-                    .foregroundStyle(Color.blueGray300)
+                if let date = scan.scanDate {
+                    Text(date.toShortDisplayString())
+                        .font(.medium, 14)
+                        .foregroundStyle(Color.blueGray300)
+                }
             }
             Spacer()
             if isSelected {
-                Image("recommend_check")
-                    .renderingMode(.template)
-                    .frame(width:24, height: 24)
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 24))
                     .foregroundStyle(Color.accentColor)
             }
         }
@@ -165,24 +213,16 @@ struct ScanSelectionRow: View {
                     if case .success(let image) = phase {
                         image.resizable().aspectRatio(contentMode: .fill)
                     } else {
-                        placeholder
+                        ImagePlaceholder()
                     }
                 }
             } else {
-                placeholder
+                ImagePlaceholder()
             }
         }
         .aspectRatio(1, contentMode: .fit)
-        .frame(maxWidth: 85)
+        .containerRelativeFrame(.horizontal) { width, _ in width * 0.18 }
         .clipShape(RoundedRectangle(cornerRadius: 10))
-    }
-
-    private var placeholder: some View {
-        Color.blueGray50
-            .overlay {
-                Image(systemName: "house.fill")
-                    .foregroundStyle(Color.blueGray300)
-            }
     }
 }
 

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonSelectView.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonSelectView.swift
@@ -56,6 +56,7 @@ private extension ComparisonSelectView {
                 ForEach(viewModel.houses) { house in
                     Button {
                         viewModel.selectHouse(house)
+                        step = .moveIn
                     } label: {
                         Text(house.name)
                             .font(.medium, 14)
@@ -144,7 +145,9 @@ private extension ComparisonSelectView {
     @ViewBuilder
     func bottomButton(pathStore: PathStore) -> some View {
         let isEnabled = (step == .moveIn && viewModel.selectedMoveInScan != nil)
-            || (step == .moveOut && viewModel.selectedMoveOutScan != nil)
+            || (step == .moveOut
+                && viewModel.selectedMoveInScan != nil
+                && viewModel.selectedMoveOutScan != nil)
 
         BottomCTAButton {
             if step == .moveIn {

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonResultViewModel.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonResultViewModel.swift
@@ -73,11 +73,16 @@ final class ComparisonResultViewModel {
                     await resumePolling(analysisId: savedId)
                     return
                 }
-            } catch let error as RepositoryError where !error.isRetryable {
-                phase = .failed(error.userMessage)
-                return
+            } catch let error as RepositoryError {
+                if error.serverErrorCode == .analysisNotFound {
+                    clearAnalysisId()
+                } else {
+                    phase = .failed(error.userMessage)
+                    return
+                }
             } catch {
-                clearAnalysisId()
+                phase = .failed(error.localizedDescription)
+                return
             }
         }
 

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonResultViewModel.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonResultViewModel.swift
@@ -1,0 +1,203 @@
+//
+//  ComparisonResultViewModel.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/3/26.
+//
+
+import Foundation
+
+@Observable
+final class ComparisonResultViewModel {
+    // MARK: - Phase
+    enum Phase: Equatable {
+        case loading
+        case polling
+        case completed
+        case failed(String)
+    }
+
+    // MARK: - State
+    private(set) var phase: Phase = .loading
+    private(set) var result: AnalysisResult?
+    private(set) var plyLocalURL: URL?
+    var errorMessage: String?
+
+    // MARK: - Context
+    let moveInRoomId: Int
+    let moveOutRoomId: Int
+    private let provider: DefectUseCaseProvider
+
+    init(moveInRoomId: Int, moveOutRoomId: Int, provider: DefectUseCaseProvider) {
+        self.moveInRoomId = moveInRoomId
+        self.moveOutRoomId = moveOutRoomId
+        self.provider = provider
+    }
+
+    // MARK: - Analysis ID Tracking
+    private static let analysisIdPrefix = "comparisonAnalysisId_"
+
+    private var storageKey: String {
+        "\(Self.analysisIdPrefix)\(moveInRoomId)_\(moveOutRoomId)"
+    }
+
+    private func savedAnalysisId() -> Int? {
+        let value = UserDefaults.standard.integer(forKey: storageKey)
+        return value == 0 ? nil : value
+    }
+
+    private func saveAnalysisId(_ id: Int) {
+        UserDefaults.standard.set(id, forKey: storageKey)
+    }
+
+    private func clearAnalysisId() {
+        UserDefaults.standard.removeObject(forKey: storageKey)
+    }
+
+    // MARK: - Main Flow
+
+    func loadOrAnalyze() async {
+        // 1. 저장된 analysisId가 있으면 상태 확인
+        if let savedId = savedAnalysisId() {
+            do {
+                let status = try await provider.makeGetAnalysisStatusUseCase().execute(analysisId: savedId).uppercased()
+                switch status {
+                case "COMPLETED":
+                    // 완료된 결과 바로 표시 (analysisId 유지 — 재진입 시 다시 조회 가능)
+                    await fetchResult(analysisId: savedId)
+                    return
+                case "FAILED":
+                    clearAnalysisId()
+                default:
+                    // PENDING → polling 재개
+                    await resumePolling(analysisId: savedId)
+                    return
+                }
+            } catch let error as RepositoryError where !error.isRetryable {
+                phase = .failed(error.userMessage)
+                return
+            } catch {
+                clearAnalysisId()
+            }
+        }
+
+        // 2. 새 분석 요청
+        await startAnalysis()
+    }
+
+    // MARK: - Analysis
+
+    func startAnalysis() async {
+        guard phase != .polling else { return }
+        phase = .polling
+
+        let analysisId: Int
+        do {
+            let result = try await provider.makeRequestAnalysisUseCase().execute(
+                inRoomId: moveInRoomId,
+                outRoomId: moveOutRoomId
+            )
+            analysisId = result.analysisId
+            saveAnalysisId(analysisId)
+
+            let status = result.status.uppercased()
+            if status == "COMPLETED" {
+                await fetchResult(analysisId: analysisId)
+                return
+            }
+            if status == "FAILED" {
+                clearAnalysisId()
+                phase = .failed("서버에서 분석에 실패했습니다")
+                return
+            }
+        } catch {
+            phase = .failed("분석 요청 실패: \(error.localizedDescription)")
+            return
+        }
+
+        await pollUntilDone(analysisId: analysisId)
+    }
+
+    private func resumePolling(analysisId: Int) async {
+        guard phase != .polling else { return }
+        phase = .polling
+        await pollUntilDone(analysisId: analysisId)
+    }
+
+    // MARK: - Polling
+
+    private enum PollConfig {
+        static let intervalSeconds = 7
+        static let maxConsecutiveErrors = 3
+    }
+
+    private func pollUntilDone(analysisId: Int) async {
+        // ply_url을 먼저 받아서 3D 이미지 표시
+        if result?.plyURL == nil {
+            if let partialResult = try? await provider.makeGetAnalysisResultUseCase().execute(analysisId: analysisId),
+               partialResult.plyURL != nil {
+                result = partialResult
+            }
+        }
+
+        var consecutiveErrors = 0
+        while !Task.isCancelled {
+            do {
+                let status = try await provider.makeGetAnalysisStatusUseCase().execute(analysisId: analysisId).uppercased()
+                consecutiveErrors = 0
+
+                if status == "COMPLETED" {
+                    break
+                } else if status == "FAILED" {
+                    clearAnalysisId()
+                    phase = .failed("서버에서 분석에 실패했습니다")
+                    return
+                }
+            } catch {
+                if Task.isCancelled { return }
+                consecutiveErrors += 1
+                if consecutiveErrors >= PollConfig.maxConsecutiveErrors {
+                    phase = .failed("상태 조회 실패: \(error.localizedDescription)")
+                    return
+                }
+            }
+
+            try? await Task.sleep(for: .seconds(PollConfig.intervalSeconds))
+        }
+
+        if Task.isCancelled { return }
+        await fetchResult(analysisId: analysisId)
+    }
+
+    // MARK: - Fetch Result
+
+    private func fetchResult(analysisId: Int) async {
+        do {
+            result = try await provider.makeGetAnalysisResultUseCase().execute(analysisId: analysisId)
+            phase = .completed
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+    }
+
+    // MARK: - PLY Download
+
+    func downloadPLYIfNeeded() async {
+        guard plyLocalURL == nil,
+              let urlString = result?.plyURL,
+              let remoteURL = URL(string: urlString) else { return }
+
+        let cacheRoomId = moveOutRoomId
+
+        if let cached = await PLYFileCache.shared.cachedFileURL(for: cacheRoomId) {
+            plyLocalURL = cached
+            return
+        }
+
+        do {
+            plyLocalURL = try await PLYFileCache.shared.download(from: remoteURL, roomId: cacheRoomId)
+        } catch {
+            print("[Comparison] PLY download failed: \(error)")
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonViewModel.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonViewModel.swift
@@ -19,6 +19,7 @@ final class ComparisonViewModel {
     var selectedMoveOutScan: ComparisonScan?
 
     private let provider: ComparisonUseCaseProvider
+    private var fetchRoomsTask: Task<Void, Never>?
 
     init(provider: ComparisonUseCaseProvider) {
         self.provider = provider
@@ -44,8 +45,11 @@ final class ComparisonViewModel {
         isLoading = true
         defer { isLoading = false }
         do {
-            rooms = try await provider.makeGetComparisonRoomsUseCase().execute(houseId: houseId)
+            let result = try await provider.makeGetComparisonRoomsUseCase().execute(houseId: houseId)
+            guard selectedHouse?.id == houseId else { return }
+            rooms = result
         } catch {
+            guard selectedHouse?.id == houseId else { return }
             rooms = []
             errorMessage = error.localizedDescription
         }
@@ -55,6 +59,7 @@ final class ComparisonViewModel {
         selectedHouse = house
         selectedMoveInScan = nil
         selectedMoveOutScan = nil
-        Task { await fetchRooms(houseId: house.id) }
+        fetchRoomsTask?.cancel()
+        fetchRoomsTask = Task { await fetchRooms(houseId: house.id) }
     }
 }

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonViewModel.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonViewModel.swift
@@ -9,10 +9,12 @@ import Foundation
 
 @Observable
 final class ComparisonViewModel {
-    private(set) var scans: [ComparisonScan] = []
+    private(set) var houses: [House] = []
+    private(set) var rooms: [ComparisonScan] = []
     private(set) var isLoading = false
     var errorMessage: String?
 
+    var selectedHouse: House?
     var selectedMoveInScan: ComparisonScan?
     var selectedMoveOutScan: ComparisonScan?
 
@@ -22,22 +24,34 @@ final class ComparisonViewModel {
         self.provider = provider
     }
 
-    func fetchScans() async {
+    func fetchHouses() async {
         isLoading = true
-        errorMessage = nil
         defer { isLoading = false }
         do {
-            scans = try await provider.makeGetComparisonScansUseCase().execute()
+            houses = try await provider.makeGetComparisonHousesUseCase().execute()
+            if selectedHouse == nil {
+                selectedHouse = houses.first
+            }
+            if let houseId = selectedHouse?.id {
+                await fetchRooms(houseId: houseId)
+            }
         } catch {
             errorMessage = error.localizedDescription
         }
     }
 
-    var moveInScans: [ComparisonScan] {
-        scans.filter { $0.scanType == .moveIn }
+    func fetchRooms(houseId: Int) async {
+        do {
+            rooms = try await provider.makeGetComparisonRoomsUseCase().execute(houseId: houseId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 
-    var moveOutScans: [ComparisonScan] {
-        scans.filter { $0.scanType == .moveOut }
+    func selectHouse(_ house: House) {
+        selectedHouse = house
+        selectedMoveInScan = nil
+        selectedMoveOutScan = nil
+        Task { await fetchRooms(houseId: house.id) }
     }
 }

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonViewModel.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonViewModel.swift
@@ -41,9 +41,12 @@ final class ComparisonViewModel {
     }
 
     func fetchRooms(houseId: Int) async {
+        isLoading = true
+        defer { isLoading = false }
         do {
             rooms = try await provider.makeGetComparisonRoomsUseCase().execute(houseId: houseId)
         } catch {
+            rooms = []
             errorMessage = error.localizedDescription
         }
     }

--- a/RoomLog/RoomLog/Features/Defect/Data/DTO/DefectDTO.swift
+++ b/RoomLog/RoomLog/Features/Defect/Data/DTO/DefectDTO.swift
@@ -27,14 +27,14 @@ struct DefectRoomSummaryDTO: Codable {
 struct DefectReportResponseDTO: Codable {
     let name: String
     let defects: [DefectDetailDTO]
-    let fileUrl: String?
+    let fileURL: String?
     let moveInDate: String?
     let moveOutDate: String?
     let defectCount: Int
 
     enum CodingKeys: String, CodingKey {
         case name, defects
-        case fileUrl = "ply_url"
+        case fileURL = "ply_url"
         case moveInDate = "move_in_date"
         case moveOutDate = "move_out_date"
         case defectCount = "defect_count"
@@ -45,14 +45,14 @@ struct DefectReportResponseDTO: Codable {
             id: roomId,
             title: name,
             date: moveInDate.flatMap { Date.fromServerDate($0) } ?? Date(),
-            thumbnailURL: fileUrl
+            thumbnailURL: fileURL
         )
         let details = defects.map { $0.toDomain() }
         let totalCost = details.reduce(0) { $0 + $1.repairCost }
         let totalArea = details.reduce(0.0) { $0 + $1.defectArea }
         return DefectReport(
             room: roomData,
-            imageURL: fileUrl,
+            imageURL: fileURL,
             defectCount: defectCount,
             minRepairCost: totalCost,
             repairArea: Float(totalArea),
@@ -96,7 +96,7 @@ struct DefectDetailDTO: Codable {
     let defectId: Int
     let analysisId: Int
     let estimatedCost: Int
-    let imageUrl: String?
+    let imageURL: String?
     let region3d: [Region3dDTO]?
 
     enum CodingKeys: String, CodingKey {
@@ -104,7 +104,7 @@ struct DefectDetailDTO: Codable {
         case defectId = "defect_id"
         case analysisId = "analysis_id"
         case estimatedCost = "estimated_cost"
-        case imageUrl = "image_url"
+        case imageURL = "image_url"
         case region3d = "region_3d"
     }
 
@@ -113,7 +113,7 @@ struct DefectDetailDTO: Codable {
         let points = region3d?.map { DefectPoint3D(x: $0.x, y: $0.y, z: $0.z) } ?? []
         return DefectReportDetail(
             id: defectId,
-            imageURL: imageUrl,
+            imageURL: imageURL,
             type: DefectType(rawString: type),
             severity: Severity(rawString: severity),
             description: description,
@@ -134,4 +134,50 @@ struct Region3dDTO: Codable {
     let x: Float
     let y: Float
     let z: Float
+}
+
+// MARK: - Analysis Result DTO
+
+struct AnalysisResultResponseDTO: Codable {
+    let status: String
+    let summary: AnalysisSummaryDTO
+    let defects: [DefectDetailDTO]
+    let analysisId: Int
+    let roomId: Int
+    let plyURL: String?
+    let createdAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case status, summary, defects
+        case analysisId = "analysis_id"
+        case roomId = "room_id"
+        case plyURL = "ply_url"
+        case createdAt = "created_at"
+    }
+
+    func toDomain() -> AnalysisResult {
+        let domainDefects = defects.map { $0.toDomain() }
+        let totalArea = domainDefects.reduce(0) { $0 + Float($1.defectArea) }
+        return AnalysisResult(
+            analysisId: analysisId,
+            roomId: roomId,
+            status: status,
+            defectCount: summary.defectCount,
+            totalCost: summary.totalCost,
+            totalArea: totalArea,
+            defects: domainDefects,
+            plyURL: plyURL,
+            createdAt: createdAt.flatMap { Date.fromServerDateTime($0) }
+        )
+    }
+}
+
+struct AnalysisSummaryDTO: Codable {
+    let defectCount: Int
+    let totalCost: Int
+
+    enum CodingKeys: String, CodingKey {
+        case defectCount = "defect_count"
+        case totalCost = "total_cost"
+    }
 }

--- a/RoomLog/RoomLog/Features/Defect/Data/Repositories/DefectRepository.swift
+++ b/RoomLog/RoomLog/Features/Defect/Data/Repositories/DefectRepository.swift
@@ -72,4 +72,15 @@ final class DefectRepository: DefectRepositoryProtocol {
         }
         return try apiResponse.unwrap().status
     }
+
+    func getAnalysisResult(analysisId: Int) async throws -> AnalysisResult {
+        let response = try await adapter.request(DefectTarget.getAnalysisResult(analysisId: analysisId))
+        let apiResponse: APIResponse<AnalysisResultResponseDTO>
+        do {
+            apiResponse = try decoder.decode(APIResponse<AnalysisResultResponseDTO>.self, from: response.data)
+        } catch {
+            throw RepositoryError.decodingError(detail: error.localizedDescription)
+        }
+        return try apiResponse.unwrap().toDomain()
+    }
 }

--- a/RoomLog/RoomLog/Features/Defect/Data/Repositories/MockDefectRepository.swift
+++ b/RoomLog/RoomLog/Features/Defect/Data/Repositories/MockDefectRepository.swift
@@ -52,4 +52,21 @@ final class MockDefectRepository: DefectRepositoryProtocol {
     func getAnalysisStatus(analysisId: Int) async throws -> String {
         return "COMPLETED"
     }
+
+    func getAnalysisResult(analysisId: Int) async throws -> AnalysisResult {
+        AnalysisResult(
+            analysisId: analysisId,
+            roomId: 1,
+            status: "COMPLETED",
+            defectCount: 2,
+            totalCost: 100000,
+            totalArea: 0.5,
+            defects: [
+                DefectReportDetail(id: 1, imageURL: nil, type: .crack, severity: .high, description: "벽면 균열", repairCost: 60000, defectArea: 0.3, location: "거실 벽", discoveredDate: nil, memo: nil, x: nil, y: nil, z: nil, region3d: []),
+                DefectReportDetail(id: 2, imageURL: nil, type: .stain, severity: .medium, description: "천장 얼룩", repairCost: 40000, defectArea: 0.2, location: "천장", discoveredDate: nil, memo: nil, x: nil, y: nil, z: nil, region3d: [])
+            ],
+            plyURL: nil,
+            createdAt: Date()
+        )
+    }
 }

--- a/RoomLog/RoomLog/Features/Defect/Data/Target/DefectTarget.swift
+++ b/RoomLog/RoomLog/Features/Defect/Data/Target/DefectTarget.swift
@@ -15,6 +15,7 @@ enum DefectTarget {
     case getDefectReportDetail(roomId: Int)
     case createAnalysis(inRoomId: Int, outRoomId: Int?)
     case getAnalysisStatus(analysisId: Int)
+    case getAnalysisResult(analysisId: Int)
 }
 
 extension DefectTarget: BaseTargetType {
@@ -28,6 +29,8 @@ extension DefectTarget: BaseTargetType {
             return "/analyses"
         case .getAnalysisStatus(let analysisId):
             return "/analyses/\(analysisId)/status"
+        case .getAnalysisResult(let analysisId):
+            return "/analyses/\(analysisId)"
         }
     }
 

--- a/RoomLog/RoomLog/Features/Defect/Domain/Interfaces/DefectRepositoryProtocol.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/Interfaces/DefectRepositoryProtocol.swift
@@ -21,4 +21,7 @@ protocol DefectRepositoryProtocol {
 
     /// 분석 상태 조회
     func getAnalysisStatus(analysisId: Int) async throws -> String
+
+    /// 분석 결과 조회
+    func getAnalysisResult(analysisId: Int) async throws -> AnalysisResult
 }

--- a/RoomLog/RoomLog/Features/Defect/Domain/Models/AnalysisResult.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/Models/AnalysisResult.swift
@@ -1,0 +1,20 @@
+//
+//  AnalysisResult.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/3/26.
+//
+
+import Foundation
+
+struct AnalysisResult {
+    let analysisId: Int
+    let roomId: Int
+    let status: String
+    let defectCount: Int
+    let totalCost: Int
+    let totalArea: Float
+    let defects: [DefectReportDetail]
+    let plyURL: String?
+    let createdAt: Date?
+}

--- a/RoomLog/RoomLog/Features/Defect/Domain/UseCases/GetAnalysisResultUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/UseCases/GetAnalysisResultUseCaseProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  GetAnalysisResultUseCaseProtocol.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/3/26.
+//
+
+import Foundation
+
+protocol GetAnalysisResultUseCaseProtocol {
+    func execute(analysisId: Int) async throws -> AnalysisResult
+}

--- a/RoomLog/RoomLog/Features/Defect/Domain/UseCases/Implementations/GetAnalysisResultUseCase.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/UseCases/Implementations/GetAnalysisResultUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  GetAnalysisResultUseCase.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/3/26.
+//
+
+import Foundation
+
+final class GetAnalysisResultUseCase: GetAnalysisResultUseCaseProtocol {
+    private let repository: DefectRepositoryProtocol
+
+    init(repository: DefectRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(analysisId: Int) async throws -> AnalysisResult {
+        try await repository.getAnalysisResult(analysisId: analysisId)
+    }
+}

--- a/RoomLog/RoomLog/Features/Defect/Presentation/DefectViewModel/DefectViewModel.swift
+++ b/RoomLog/RoomLog/Features/Defect/Presentation/DefectViewModel/DefectViewModel.swift
@@ -61,12 +61,15 @@ final class DefectViewModel {
                 phase = .completed
                 return
             }
-        } catch let error as RepositoryError where !error.isRetryable {
-            // 디코딩 에러 등 재시도 불가 → 실패
-            phase = .failed(error.userMessage)
-            return
+        } catch let error as RepositoryError {
+            if !error.isRetryable {
+                phase = .failed(error.userMessage)
+                return
+            }
+            // 서버 에러 → 분석 필요할 수 있으므로 계속 진행
         } catch {
-            // 서버 에러(404 포함) → 분석 필요할 수 있으므로 계속 진행
+            phase = .failed(error.localizedDescription)
+            return
         }
 
         // 2. 저장된 analysisId가 있으면 상태 확인 (중복 분석 방지)
@@ -84,12 +87,16 @@ final class DefectViewModel {
                     await resumePolling(analysisId: savedId)
                     return
                 }
-            } catch let error as RepositoryError where !error.isRetryable {
-                phase = .failed(error.userMessage)
-                return
+            } catch let error as RepositoryError {
+                if error.serverErrorCode == .analysisNotFound {
+                    Self.clearAnalysisId(for: roomId)
+                } else {
+                    phase = .failed(error.userMessage)
+                    return
+                }
             } catch {
-                // 서버 에러 → 저장값 무효로 판단, 새 분석 허용
-                Self.clearAnalysisId(for: roomId)
+                phase = .failed(error.localizedDescription)
+                return
             }
         }
 

--- a/RoomLog/RoomLog/Features/Defect/Presentation/Provider/DefectUseCaseProvider.swift
+++ b/RoomLog/RoomLog/Features/Defect/Presentation/Provider/DefectUseCaseProvider.swift
@@ -13,6 +13,7 @@ protocol DefectUseCaseProvider {
     func makeGetDefectReportDetailUseCase() -> GetDefectReportDetailUseCaseProtocol
     func makeRequestAnalysisUseCase() -> RequestAnalysisUseCaseProtocol
     func makeGetAnalysisStatusUseCase() -> GetAnalysisStatusUseCaseProtocol
+    func makeGetAnalysisResultUseCase() -> GetAnalysisResultUseCaseProtocol
 }
 
 final class DefectUseCaseProviderImpl: DefectUseCaseProvider {
@@ -43,5 +44,9 @@ final class DefectUseCaseProviderImpl: DefectUseCaseProvider {
 
     func makeGetAnalysisStatusUseCase() -> GetAnalysisStatusUseCaseProtocol {
         GetAnalysisStatusUseCase(repository: defectRepository)
+    }
+
+    func makeGetAnalysisResultUseCase() -> GetAnalysisResultUseCaseProtocol {
+        GetAnalysisResultUseCase(repository: defectRepository)
     }
 }


### PR DESCRIPTION
## ✨ PR 유형
- [x] 새로운 기능 추가

<br>

## 🛠️ 작업 내용
- <!-- 작업 내용 작성 -->GET /analyses/{id} 분석 결과 조회 API 연동
- 내방비교 스캔 선택 Mock → 실제 API 연동 (집 목록 + 방 목록 조회)                        
- 내방비교 결과 화면 DefectView와 동일 구조로 재작성 (3D PLY + 하자 오버레이 + 요약 + 리스트)                                                                                 
- 네비게이션 파라미터 scanId → roomId 변경                                                
- polling 중 ply_url 선조회하여 3D 모델 먼저 표시                                         
- 완료된 분석 재진입 시 결과 즉시 표시 (중복 분석 방지)   

<br>

## 🔍 관련 이슈
- closed #116

<br>

## 📸 스크린샷 - UI작업인 경우만 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 비교 결과 화면에 분석 단계별 로드/폴링 UI와 3D PLY 시각화 추가
  - 하우스·룸 기반 비교 흐름 도입(선택 단계 분리 및 단계별 진행)

- **Improvements**
  - 분석 재시도·상태 폴링 및 상세 오류 메시지 개선
  - 로딩/빈 상태 UI 개선, 썸네일·날짜 표시 및 비용 포맷 개선

- **Bug Fixes**
  - 비교 선택/경로 처리와 관련된 일관성 문제 수정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->