### PR TITLE
[Feat] 내방비교 UI 구현

### DIFF
--- a/RoomLog/RoomLog/Core/Common/Extensions/Int+FormattedCost.swift
+++ b/RoomLog/RoomLog/Core/Common/Extensions/Int+FormattedCost.swift
@@ -1,0 +1,18 @@
+//
+//  Int+FormattedCost.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/3/26.
+//
+
+import Foundation
+
+extension Int {
+    var formattedCost: String {
+        let manWon = self / 10000
+        if manWon > 0 { return "\(manWon)만원" }
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        return "\(f.string(from: NSNumber(value: self)) ?? "\(self)")원"
+    }
+}

--- a/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationDestination.swift
@@ -32,6 +32,7 @@ enum NavigationDestination: Hashable {
         case repairHistory(roomId: Int)
         
         /// 내방비교 case
+        case comparisonHistory
         case comparisonSelect
         case comparisonResult(moveInRoomId: Int, moveOutRoomId: Int)
     }

--- a/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
+++ b/RoomLog/RoomLog/Core/Navigation/NavigationRoutingView.swift
@@ -82,6 +82,8 @@ private extension NavigationRoutingView {
             RepairShopListView(roomId: roomId, defect: defect, provider: di.resolve(EstimateUseCaseProvider.self))
         case .repairHistory(let roomId):
             RepairHistoryView(roomId: roomId, provider: di.resolve(EstimateUseCaseProvider.self))
+        case .comparisonHistory:
+            ComparisonHistoryView(provider: di.resolve(ComparisonUseCaseProvider.self))
         case .comparisonSelect:
             ComparisonSelectView(provider: di.resolve(ComparisonUseCaseProvider.self))
         case .comparisonResult(let moveInRoomId, let moveOutRoomId):

--- a/RoomLog/RoomLog/Features/Comparison/Domain/Models/ComparisonHistory.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Domain/Models/ComparisonHistory.swift
@@ -1,0 +1,19 @@
+//
+//  ComparisonHistory.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/3/26.
+//
+
+import Foundation
+
+struct ComparisonHistory: Identifiable, Hashable {
+    let id: Int // analysisId
+    let moveInRoomName: String
+    let moveOutRoomName: String
+    let defectCount: Int
+    let totalCost: Int
+    let createdAt: Date?
+    let moveInRoomId: Int
+    let moveOutRoomId: Int
+}

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonHistoryView.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonHistoryView.swift
@@ -28,6 +28,12 @@ struct ComparisonHistoryView: View {
                 Spacer()
                 ProgressView()
                 Spacer()
+            } else if let errorMessage = viewModel.errorMessage {
+                Spacer()
+                Text(errorMessage)
+                    .font(.medium, 14)
+                    .foregroundStyle(Color.blueGray500)
+                Spacer()
             } else if viewModel.histories.isEmpty {
                 Spacer()
                 emptyView

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonHistoryView.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonHistoryView.swift
@@ -1,0 +1,195 @@
+//
+//  ComparisonHistoryView.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/3/26.
+//
+
+import SwiftUI
+
+struct ComparisonHistoryView: View {
+    @Environment(\.di) var di
+    @State private var viewModel: ComparisonHistoryViewModel
+
+    init(provider: ComparisonUseCaseProvider) {
+        self._viewModel = .init(
+            wrappedValue: ComparisonHistoryViewModel(provider: provider)
+        )
+    }
+
+    var body: some View {
+        let pathStore = di.resolve(PathStore.self)
+        VStack(spacing: 0) {
+            if !viewModel.houses.isEmpty {
+                houseSelector
+            }
+
+            if viewModel.isLoading {
+                Spacer()
+                ProgressView()
+                Spacer()
+            } else if viewModel.histories.isEmpty {
+                Spacer()
+                emptyView
+                Spacer()
+            } else {
+                historyList(pathStore: pathStore)
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            newComparisonButton(pathStore: pathStore)
+        }
+        .navigationTitle("내 방 비교")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await viewModel.fetchHouses()
+        }
+    }
+}
+
+// MARK: - House Selector
+private extension ComparisonHistoryView {
+    var houseSelector: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(viewModel.houses) { house in
+                    Button {
+                        viewModel.selectHouse(house)
+                    } label: {
+                        Text(house.name)
+                            .font(.medium, 14)
+                            .foregroundStyle(viewModel.selectedHouse?.id == house.id ? .white : Color.neutral800)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .background(
+                                viewModel.selectedHouse?.id == house.id ? Color.mutedBlue : Color.blueGray50,
+                                in: Capsule()
+                            )
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+    }
+}
+
+// MARK: - History List
+private extension ComparisonHistoryView {
+    func historyList(pathStore: PathStore) -> some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                ForEach(viewModel.histories) { history in
+                    ComparisonHistoryCard(history: history)
+                        .onTapGesture {
+                            pathStore.defectPath.append(
+                                .defect(.comparisonResult(
+                                    moveInRoomId: history.moveInRoomId,
+                                    moveOutRoomId: history.moveOutRoomId
+                                ))
+                            )
+                        }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+    }
+}
+
+// MARK: - Empty View
+private extension ComparisonHistoryView {
+    var emptyView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "arrow.left.and.right.square")
+                .font(.system(size: 48))
+                .foregroundStyle(Color.blueGray300)
+            Text("비교 내역이 없습니다")
+                .font(.medium, 16)
+                .foregroundStyle(Color.blueGray500)
+            Text("새 비교를 시작해보세요")
+                .font(.regular, 14)
+                .foregroundStyle(Color.blueGray300)
+        }
+    }
+}
+
+// MARK: - New Comparison Button
+private extension ComparisonHistoryView {
+    func newComparisonButton(pathStore: PathStore) -> some View {
+        BottomCTAButton {
+            pathStore.defectPath.append(.defect(.comparisonSelect))
+        } label: {
+            Text("새 비교하기")
+                .font(.semibold, 17)
+        }
+    }
+}
+
+// MARK: - History Card
+private struct ComparisonHistoryCard: View {
+    let history: ComparisonHistory
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // 상단: 방 이름 비교
+            HStack(spacing: 10) {
+                roomLabel(history.moveInRoomName, subtitle: "입주 전")
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Color.blueGray300)
+                roomLabel(history.moveOutRoomName, subtitle: "퇴거 후")
+                Spacer()
+            }
+
+            Divider()
+
+            // 하단: 요약 정보
+            HStack(spacing: 16) {
+                if let date = history.createdAt {
+                    infoChip(icon: "calendar", text: date.toShortDisplayString())
+                }
+                infoChip(icon: "exclamationmark.triangle", text: "하자 \(history.defectCount)건")
+                infoChip(icon: "wonsign.circle", text: history.totalCost.formattedCost)
+            }
+        }
+        .padding(16)
+        .background(.white, in: RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.1), radius: 6, x: 0, y: 2)
+    }
+
+    private func roomLabel(_ name: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(subtitle)
+                .font(.regular, 12)
+                .foregroundStyle(Color.blueGray400)
+            Text(name)
+                .font(.semibold, 16)
+                .foregroundStyle(Color.neutral800)
+        }
+        .padding(.horizontal, 5)
+    }
+
+    private func infoChip(icon: String, text: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+                .foregroundStyle(Color.blueGray400)
+            Text(text)
+                .font(.medium, 13)
+                .foregroundStyle(Color.blueGray600)
+        }
+    }
+}
+
+
+#Preview {
+    NavigationStack {
+        ComparisonHistoryView(
+            provider: ComparisonUseCaseProviderImpl(
+                repository: MockComparisonRepository()
+            )
+        )
+    }
+    .environment(\.di, DIContainer.configured())
+}

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonResultView.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonResultView.swift
@@ -118,7 +118,7 @@ private extension ComparisonResultView {
 
             HStack(spacing: 0) {
                 SummaryStatView(value: "\(result.defectCount)", label: "하자")
-                SummaryStatView(value: formattedCost(result.totalCost), label: "예상 수리비")
+                SummaryStatView(value: result.totalCost.formattedCost, label: "예상 수리비")
                 SummaryStatView(value: String(format: "%.1fm²", result.totalArea), label: "면적")
             }
 
@@ -131,13 +131,6 @@ private extension ComparisonResultView {
         .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 2)
     }
 
-    func formattedCost(_ cost: Int) -> String {
-        let manWon = cost / 10000
-        if manWon > 0 { return "\(manWon)만원" }
-        let f = NumberFormatter()
-        f.numberStyle = .decimal
-        return "\(f.string(from: NSNumber(value: cost)) ?? "\(cost)")원"
-    }
 }
 
 // MARK: - Defect List

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonHistoryViewModel.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonHistoryViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@MainActor
 @Observable
 final class ComparisonHistoryViewModel {
     private(set) var houses: [House] = []
@@ -26,7 +27,10 @@ final class ComparisonHistoryViewModel {
         defer { isLoading = false }
         do {
             houses = try await provider.makeGetComparisonHousesUseCase().execute()
-            if selectedHouse == nil {
+            if let selected = selectedHouse,
+               houses.contains(where: { $0.id == selected.id }) {
+                selectedHouse = selected
+            } else {
                 selectedHouse = houses.first
             }
             loadMockHistories()

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonHistoryViewModel.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonHistoryViewModel.swift
@@ -1,0 +1,73 @@
+//
+//  ComparisonHistoryViewModel.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/3/26.
+//
+
+import Foundation
+
+@Observable
+final class ComparisonHistoryViewModel {
+    private(set) var houses: [House] = []
+    private(set) var histories: [ComparisonHistory] = []
+    private(set) var isLoading = false
+    var errorMessage: String?
+    var selectedHouse: House?
+
+    private let provider: ComparisonUseCaseProvider
+
+    init(provider: ComparisonUseCaseProvider) {
+        self.provider = provider
+    }
+
+    func fetchHouses() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            houses = try await provider.makeGetComparisonHousesUseCase().execute()
+            if selectedHouse == nil {
+                selectedHouse = houses.first
+            }
+            loadMockHistories()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func selectHouse(_ house: House) {
+        selectedHouse = house
+        loadMockHistories()
+    }
+
+    // TODO: 서버 API 연동 시 교체
+    private func loadMockHistories() {
+        guard let house = selectedHouse else {
+            histories = []
+            return
+        }
+        // Mock 데이터 — 추후 GET /analyses?houseId= 로 교체
+        histories = [
+            ComparisonHistory(
+                id: 101,
+                moveInRoomName: "거실",
+                moveOutRoomName: "거실",
+                defectCount: 3,
+                totalCost: 150000,
+                createdAt: Date(timeIntervalSinceNow: -86400 * 2),
+                moveInRoomId: 1,
+                moveOutRoomId: 4
+            ),
+            ComparisonHistory(
+                id: 102,
+                moveInRoomName: "안방",
+                moveOutRoomName: "안방",
+                defectCount: 1,
+                totalCost: 50000,
+                createdAt: Date(timeIntervalSinceNow: -86400 * 7),
+                moveInRoomId: 2,
+                moveOutRoomId: 5
+            )
+        ]
+    }
+}

--- a/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectView.swift
+++ b/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectView.swift
@@ -179,7 +179,7 @@ private extension DefectView {
 
             HStack(spacing: 0) {
                 SummaryStatView(value: "\(report.defectCount)", label: "하자")
-                SummaryStatView(value: formattedCost(report.minRepairCost), label: "예상 수리비")
+                SummaryStatView(value: report.minRepairCost.formattedCost, label: "예상 수리비")
                 SummaryStatView(value: String(format: "%.1fm²", report.repairArea), label: "면적")
             }
 
@@ -192,13 +192,6 @@ private extension DefectView {
         .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 2)
     }
 
-    func formattedCost(_ cost: Int) -> String {
-        let manWon = cost / 10000
-        if manWon > 0 { return "\(manWon)만원" }
-        let f = NumberFormatter()
-        f.numberStyle = .decimal
-        return "\(f.string(from: NSNumber(value: cost)) ?? "\(cost)")원"
-    }
 }
 
 // MARK: - Section 3: 하자 리스트

--- a/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerView.swift
+++ b/RoomLog/RoomLog/Features/Viewer/Presentation/ViewerView.swift
@@ -141,7 +141,7 @@ private extension ViewerView {
                         .foregroundStyle(Color.dustyBlue)
                         .lineSpacing(6)
                     Button {
-                        pathStore.defectPath.append(.defect(.comparisonSelect))
+                        pathStore.defectPath.append(.defect(.comparisonHistory))
                     } label: {
                         Circle()
                             .fill(Color(red: 0.79, green: 0.87, blue: 0.92))


### PR DESCRIPTION
## ✨ PR 유형
- [x] <!-- 변경 사항 작성 -->새로운 기능 추가
- [x] 코드 리팩토링

<br>

## 🛠️ 작업 내용
- <!-- 작업 내용 작성 -->내방비교 내역 목록 화면 UI 구현 (집 선택 → 비교 내역 리스트 → 결과 화면 or 새 비교하기) 
- ComparisonHistoryCard 컴포넌트 구현 (비교한 방 이름, 날짜, 하자 수, 비용)             
- 네비게이션 플로우 변경 (내방비교 → 내역 목록 → 방 선택 or 결과)                         
- formattedCost를 Int extension으로 공통화                                                
- API 연동은 서버 API 확정 후 별도 작업 예정 (현재 Mock 데이터)   

<br>

## 🔍 관련 이슈
- closed #125 

<br>

## 📸 스크린샷 - UI작업인 경우만 추가
<img width="270" height="548" alt="내방비교" src="https://github.com/user-attachments/assets/79d28ec9-efd9-436b-8ffb-aaf22d090dac" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 방 비교 이력 화면 추가: 과거 비교 결과를 이력으로 관리하며, 각 비교의 입주/퇴거 방 정보, 하자 건수, 예상 수리비, 생성 날짜를 확인할 수 있습니다.

* **개선사항**
  * 금액 표시 개선: 앱 전역에서 일관된 금액 포맷팅을 적용하여 만원 이상 금액은 간결하게, 그 이하는 세자리 구분으로 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->