### PR TITLE
[Feat] 내방비교 내역 목록 API 연동

### DIFF
--- a/RoomLog/RoomLog/Core/Common/UIComponents/InfoChip.swift
+++ b/RoomLog/RoomLog/Core/Common/UIComponents/InfoChip.swift
@@ -1,0 +1,24 @@
+//
+//  InfoChip.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/4/26.
+//
+
+import SwiftUI
+
+struct InfoChip: View {
+    let icon: String
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+                .foregroundStyle(Color.blueGray400)
+            Text(text)
+                .font(.medium, 13)
+                .foregroundStyle(Color.blueGray600)
+        }
+    }
+}

--- a/RoomLog/RoomLog/Core/Common/UIComponents/StatusBadge.swift
+++ b/RoomLog/RoomLog/Core/Common/UIComponents/StatusBadge.swift
@@ -1,0 +1,56 @@
+//
+//  StatusBadge.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/4/26.
+//
+
+import SwiftUI
+
+struct StatusBadge: View {
+    let label: String
+    let foreground: Color
+    let background: Color
+
+    var body: some View {
+        Text(label)
+            .font(.system(size: 13, weight: .medium))
+            .foregroundStyle(foreground)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(background, in: Capsule())
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension StatusBadge {
+    /// 분석 상태 뱃지
+    init(analysisStatus: AnalysisStatus) {
+        self.label = analysisStatus.label
+        switch analysisStatus {
+        case .completed:
+            self.foreground = Color.mutedBlue
+            self.background = Color.blueGray50
+        case .pending:
+            self.foreground = .white
+            self.background = Color.mutedBlue
+        case .failed:
+            self.foreground = .white
+            self.background = Color(red: 0.89, green: 0.21, blue: 0.22)
+        }
+    }
+
+    /// 견적 상태 뱃지
+    init(estimateStatus: EstimateDisplayStatus) {
+        self.label = estimateStatus.label
+        switch estimateStatus {
+        case .inProgress:
+            self.foreground = .white
+            self.background = Color.mutedBlue
+        case .completed:
+            self.foreground = Color.mutedBlue
+            self.background = Color.blueGray50
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Comparison/Data/DTO/ComparisonDTO.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Data/DTO/ComparisonDTO.swift
@@ -1,0 +1,61 @@
+//
+//  ComparisonDTO.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/4/26.
+//
+
+import Foundation
+
+struct ComparisonHistoryDTO: Codable {
+    let status: String
+    let summary: ComparisonSummaryDTO
+    let analysisID: Int
+    let createdAt: String?
+    let inRoom: ComparisonRoomDTO
+    let outRoom: ComparisonRoomDTO
+
+    enum CodingKeys: String, CodingKey {
+        case status, summary
+        case analysisID = "analysis_id"
+        case createdAt = "created_at"
+        case inRoom = "in_room"
+        case outRoom = "out_room"
+    }
+
+    func toDomain() -> ComparisonHistory {
+        ComparisonHistory(
+            id: analysisID,
+            status: AnalysisStatus(rawString: status),
+            moveInRoomName: inRoom.name,
+            moveOutRoomName: outRoom.name,
+            defectCount: summary.defectCount,
+            totalCost: summary.totalCost,
+            createdAt: createdAt.flatMap { Date.fromServerDateTime($0) },
+            moveInRoomId: inRoom.roomID,
+            moveOutRoomId: outRoom.roomID
+        )
+    }
+}
+
+struct ComparisonSummaryDTO: Codable {
+    let defectCount: Int
+    let totalCost: Int
+
+    enum CodingKeys: String, CodingKey {
+        case defectCount = "defect_count"
+        case totalCost = "total_cost"
+    }
+}
+
+struct ComparisonRoomDTO: Codable {
+    let name: String
+    let roomID: Int
+    let thumbnailURL: String?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case roomID = "room_id"
+        case thumbnailURL = "thumbnail_url"
+    }
+}

--- a/RoomLog/RoomLog/Features/Comparison/Data/Repositories/ComparisonRepository.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Data/Repositories/ComparisonRepository.swift
@@ -45,4 +45,15 @@ final class ComparisonRepository: ComparisonRepositoryProtocol {
             )
         }
     }
+
+    func getComparisonHistories(houseId: Int) async throws -> [ComparisonHistory] {
+        let response = try await adapter.request(ComparisonTarget.getComparisonHistories(houseId: houseId))
+        let apiResponse: APIResponse<[ComparisonHistoryDTO]>
+        do {
+            apiResponse = try decoder.decode(APIResponse<[ComparisonHistoryDTO]>.self, from: response.data)
+        } catch {
+            throw RepositoryError.decodingError(detail: error.localizedDescription)
+        }
+        return try apiResponse.unwrap().map { $0.toDomain() }
+    }
 }

--- a/RoomLog/RoomLog/Features/Comparison/Data/Repositories/MockComparisonRepository.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Data/Repositories/MockComparisonRepository.swift
@@ -22,4 +22,11 @@ final class MockComparisonRepository: ComparisonRepositoryProtocol {
             ComparisonScan(id: 3, roomName: "주방", scanDate: Date(timeIntervalSinceNow: -86400 * 45), thumbnailURL: nil)
         ]
     }
+
+    func getComparisonHistories(houseId: Int) async throws -> [ComparisonHistory] {
+        [
+            ComparisonHistory(id: 101, status: .completed, moveInRoomName: "거실", moveOutRoomName: "거실", defectCount: 3, totalCost: 150000, createdAt: Date(timeIntervalSinceNow: -86400 * 2), moveInRoomId: 1, moveOutRoomId: 4),
+            ComparisonHistory(id: 102, status: .pending, moveInRoomName: "안방", moveOutRoomName: "안방", defectCount: 0, totalCost: 0, createdAt: Date(timeIntervalSinceNow: -86400 * 1), moveInRoomId: 2, moveOutRoomId: 5)
+        ]
+    }
 }

--- a/RoomLog/RoomLog/Features/Comparison/Data/Target/ComparisonTarget.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Data/Target/ComparisonTarget.swift
@@ -1,0 +1,40 @@
+//
+//  ComparisonTarget.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/4/26.
+//
+
+import Foundation
+import Moya
+internal import Alamofire
+
+enum ComparisonTarget {
+    case getComparisonHistories(houseId: Int)
+}
+
+extension ComparisonTarget: BaseTargetType {
+    var path: String {
+        switch self {
+        case .getComparisonHistories:
+            return "/analyses"
+        }
+    }
+
+    var method: Moya.Method {
+        switch self {
+        case .getComparisonHistories:
+            return .get
+        }
+    }
+
+    var task: Moya.Task {
+        switch self {
+        case .getComparisonHistories(let houseId):
+            return .requestParameters(
+                parameters: ["houseId": houseId],
+                encoding: URLEncoding.queryString
+            )
+        }
+    }
+}

--- a/RoomLog/RoomLog/Features/Comparison/Domain/Interfaces/ComparisonRepositoryProtocol.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Domain/Interfaces/ComparisonRepositoryProtocol.swift
@@ -12,4 +12,6 @@ protocol ComparisonRepositoryProtocol {
     func getHouses() async throws -> [House]
     /// 집의 방 목록 조회
     func getRooms(houseId: Int) async throws -> [ComparisonScan]
+    /// 비교 분석 내역 조회
+    func getComparisonHistories(houseId: Int) async throws -> [ComparisonHistory]
 }

--- a/RoomLog/RoomLog/Features/Comparison/Domain/Models/ComparisonHistory.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Domain/Models/ComparisonHistory.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct ComparisonHistory: Identifiable, Hashable {
     let id: Int // analysisId
+    let status: AnalysisStatus
     let moveInRoomName: String
     let moveOutRoomName: String
     let defectCount: Int
@@ -16,4 +17,26 @@ struct ComparisonHistory: Identifiable, Hashable {
     let createdAt: Date?
     let moveInRoomId: Int
     let moveOutRoomId: Int
+
+    var isCompleted: Bool { status == .completed }
+}
+
+enum AnalysisStatus: Hashable {
+    case pending, completed, failed
+
+    init(rawString: String) {
+        switch rawString.uppercased() {
+        case "COMPLETED": self = .completed
+        case "FAILED": self = .failed
+        default: self = .pending
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .pending: "분석 중"
+        case .completed: "완료"
+        case .failed: "실패"
+        }
+    }
 }

--- a/RoomLog/RoomLog/Features/Comparison/Domain/UseCases/GetComparisonHistoriesUseCaseProtocol.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Domain/UseCases/GetComparisonHistoriesUseCaseProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  GetComparisonHistoriesUseCaseProtocol.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/4/26.
+//
+
+import Foundation
+
+protocol GetComparisonHistoriesUseCaseProtocol {
+    func execute(houseId: Int) async throws -> [ComparisonHistory]
+}

--- a/RoomLog/RoomLog/Features/Comparison/Domain/UseCases/Implementations/GetComparisonHistoriesUseCase.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Domain/UseCases/Implementations/GetComparisonHistoriesUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  GetComparisonHistoriesUseCase.swift
+//  RoomLog
+//
+//  Created by minkyo on 6/4/26.
+//
+
+import Foundation
+
+final class GetComparisonHistoriesUseCase: GetComparisonHistoriesUseCaseProtocol {
+    private let repository: ComparisonRepositoryProtocol
+
+    init(repository: ComparisonRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(houseId: Int) async throws -> [ComparisonHistory] {
+        try await repository.getComparisonHistories(houseId: houseId)
+    }
+}

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/Provider/ComparisonUseCaseProvider.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/Provider/ComparisonUseCaseProvider.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol ComparisonUseCaseProvider {
     func makeGetComparisonHousesUseCase() -> GetComparisonHousesUseCaseProtocol
     func makeGetComparisonRoomsUseCase() -> GetComparisonRoomsUseCaseProtocol
+    func makeGetComparisonHistoriesUseCase() -> GetComparisonHistoriesUseCaseProtocol
 }
 
 final class ComparisonUseCaseProviderImpl: ComparisonUseCaseProvider {
@@ -29,5 +30,9 @@ final class ComparisonUseCaseProviderImpl: ComparisonUseCaseProvider {
 
     func makeGetComparisonRoomsUseCase() -> GetComparisonRoomsUseCaseProtocol {
         GetComparisonRoomsUseCase(repository: repository)
+    }
+
+    func makeGetComparisonHistoriesUseCase() -> GetComparisonHistoriesUseCaseProtocol {
+        GetComparisonHistoriesUseCase(repository: repository)
     }
 }

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonHistoryView.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/View/ComparisonHistoryView.swift
@@ -87,7 +87,9 @@ private extension ComparisonHistoryView {
             LazyVStack(spacing: 12) {
                 ForEach(viewModel.histories) { history in
                     ComparisonHistoryCard(history: history)
+                        .opacity(history.isCompleted ? 1 : 0.7)
                         .onTapGesture {
+                            guard history.isCompleted else { return }
                             pathStore.defectPath.append(
                                 .defect(.comparisonResult(
                                     moveInRoomId: history.moveInRoomId,
@@ -138,7 +140,7 @@ private struct ComparisonHistoryCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            // 상단: 방 이름 비교
+            // 상단: 방 이름 + 상태 뱃지
             HStack(spacing: 10) {
                 roomLabel(history.moveInRoomName, subtitle: "입주 전")
                 Image(systemName: "arrow.right")
@@ -146,6 +148,7 @@ private struct ComparisonHistoryCard: View {
                     .foregroundStyle(Color.blueGray300)
                 roomLabel(history.moveOutRoomName, subtitle: "퇴거 후")
                 Spacer()
+                StatusBadge(analysisStatus: history.status)
             }
 
             Divider()
@@ -153,10 +156,12 @@ private struct ComparisonHistoryCard: View {
             // 하단: 요약 정보
             HStack(spacing: 16) {
                 if let date = history.createdAt {
-                    infoChip(icon: "calendar", text: date.toShortDisplayString())
+                    InfoChip(icon: "calendar", text: date.toShortDisplayString())
                 }
-                infoChip(icon: "exclamationmark.triangle", text: "하자 \(history.defectCount)건")
-                infoChip(icon: "wonsign.circle", text: history.totalCost.formattedCost)
+                if history.isCompleted {
+                    InfoChip(icon: "exclamationmark.triangle", text: "하자 \(history.defectCount)건")
+                    InfoChip(icon: "wonsign.circle", text: history.totalCost.formattedCost)
+                }
             }
         }
         .padding(16)
@@ -174,17 +179,6 @@ private struct ComparisonHistoryCard: View {
                 .foregroundStyle(Color.neutral800)
         }
         .padding(.horizontal, 5)
-    }
-
-    private func infoChip(icon: String, text: String) -> some View {
-        HStack(spacing: 4) {
-            Image(systemName: icon)
-                .font(.system(size: 12))
-                .foregroundStyle(Color.blueGray400)
-            Text(text)
-                .font(.medium, 13)
-                .foregroundStyle(Color.blueGray600)
-        }
     }
 }
 

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonHistoryViewModel.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonHistoryViewModel.swift
@@ -17,6 +17,7 @@ final class ComparisonHistoryViewModel {
     var selectedHouse: House?
 
     private let provider: ComparisonUseCaseProvider
+    private var fetchHistoriesTask: Task<Void, Never>?
 
     init(provider: ComparisonUseCaseProvider) {
         self.provider = provider
@@ -43,13 +44,17 @@ final class ComparisonHistoryViewModel {
 
     func selectHouse(_ house: House) {
         selectedHouse = house
-        Task { await fetchHistories(houseId: house.id) }
+        fetchHistoriesTask?.cancel()
+        fetchHistoriesTask = Task { await fetchHistories(houseId: house.id) }
     }
 
     private func fetchHistories(houseId: Int) async {
         do {
-            histories = try await provider.makeGetComparisonHistoriesUseCase().execute(houseId: houseId)
+            let fetched = try await provider.makeGetComparisonHistoriesUseCase().execute(houseId: houseId)
+            guard !Task.isCancelled, selectedHouse?.id == houseId else { return }
+            histories = fetched
         } catch {
+            guard !Task.isCancelled else { return }
             histories = []
             errorMessage = error.localizedDescription
         }

--- a/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonHistoryViewModel.swift
+++ b/RoomLog/RoomLog/Features/Comparison/Presentation/ViewModel/ComparisonHistoryViewModel.swift
@@ -33,7 +33,9 @@ final class ComparisonHistoryViewModel {
             } else {
                 selectedHouse = houses.first
             }
-            loadMockHistories()
+            if let houseId = selectedHouse?.id {
+                await fetchHistories(houseId: houseId)
+            }
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -41,37 +43,15 @@ final class ComparisonHistoryViewModel {
 
     func selectHouse(_ house: House) {
         selectedHouse = house
-        loadMockHistories()
+        Task { await fetchHistories(houseId: house.id) }
     }
 
-    // TODO: 서버 API 연동 시 교체
-    private func loadMockHistories() {
-        guard let house = selectedHouse else {
+    private func fetchHistories(houseId: Int) async {
+        do {
+            histories = try await provider.makeGetComparisonHistoriesUseCase().execute(houseId: houseId)
+        } catch {
             histories = []
-            return
+            errorMessage = error.localizedDescription
         }
-        // Mock 데이터 — 추후 GET /analyses?houseId= 로 교체
-        histories = [
-            ComparisonHistory(
-                id: 101,
-                moveInRoomName: "거실",
-                moveOutRoomName: "거실",
-                defectCount: 3,
-                totalCost: 150000,
-                createdAt: Date(timeIntervalSinceNow: -86400 * 2),
-                moveInRoomId: 1,
-                moveOutRoomId: 4
-            ),
-            ComparisonHistory(
-                id: 102,
-                moveInRoomName: "안방",
-                moveOutRoomName: "안방",
-                defectCount: 1,
-                totalCost: 50000,
-                createdAt: Date(timeIntervalSinceNow: -86400 * 7),
-                moveInRoomId: 2,
-                moveOutRoomId: 5
-            )
-        ]
     }
 }

--- a/RoomLog/RoomLog/Features/Defect/Data/DTO/DefectDTO.swift
+++ b/RoomLog/RoomLog/Features/Defect/Data/DTO/DefectDTO.swift
@@ -113,6 +113,7 @@ struct DefectDetailDTO: Codable {
         let points = region3d?.map { DefectPoint3D(x: $0.x, y: $0.y, z: $0.z) } ?? []
         return DefectReportDetail(
             id: defectId,
+            analysisID: analysisId,
             imageURL: imageURL,
             type: DefectType(rawString: type),
             severity: Severity(rawString: severity),

--- a/RoomLog/RoomLog/Features/Defect/Data/Repositories/MockDefectRepository.swift
+++ b/RoomLog/RoomLog/Features/Defect/Data/Repositories/MockDefectRepository.swift
@@ -19,9 +19,9 @@ final class MockDefectRepository: DefectRepositoryProtocol {
     func getDefectReport(roomId: Int) async throws -> DefectReport {
         let room = DefectRoomData(id: roomId, title: "망고의 방", date: Date(), thumbnailURL: nil)
         let defects = [
-            DefectReportDetail(id: 1, imageURL: nil, type: .crack, severity: .high, description: "벽면 균열 발견", repairCost: 80000, defectArea: 0.3, location: "거실 북쪽 벽", discoveredDate: nil, memo: nil, x: 0.3, y: 0.4, z: nil, region3d: []),
-            DefectReportDetail(id: 2, imageURL: nil, type: .stain, severity: .medium, description: "화장실 천장 곰팡이", repairCost: 50000, defectArea: 0.2, location: "화장실 천장", discoveredDate: nil, memo: nil, x: 0.7, y: 0.2, z: nil, region3d: []),
-            DefectReportDetail(id: 3, imageURL: nil, type: .peeling, severity: .low, description: "벽지 뜯김", repairCost: 20000, defectArea: 0.1, location: "침실 동쪽 벽", discoveredDate: nil, memo: nil, x: 0.5, y: 0.6, z: nil, region3d: [])
+            DefectReportDetail(id: 1, analysisID: 1, imageURL: nil, type: .crack, severity: .high, description: "벽면 균열 발견", repairCost: 80000, defectArea: 0.3, location: "거실 북쪽 벽", discoveredDate: nil, memo: nil, x: 0.3, y: 0.4, z: nil, region3d: []),
+            DefectReportDetail(id: 2, analysisID: 1, imageURL: nil, type: .stain, severity: .medium, description: "화장실 천장 곰팡이", repairCost: 50000, defectArea: 0.2, location: "화장실 천장", discoveredDate: nil, memo: nil, x: 0.7, y: 0.2, z: nil, region3d: []),
+            DefectReportDetail(id: 3, analysisID: 1, imageURL: nil, type: .peeling, severity: .low, description: "벽지 뜯김", repairCost: 20000, defectArea: 0.1, location: "침실 동쪽 벽", discoveredDate: nil, memo: nil, x: 0.5, y: 0.6, z: nil, region3d: [])
         ]
         return DefectReport(room: room, imageURL: nil, defectCount: defects.count, minRepairCost: 150000, repairArea: 0.6, defects: defects)
     }
@@ -29,6 +29,7 @@ final class MockDefectRepository: DefectRepositoryProtocol {
     func getDefectReportDetail(roomId: Int) async throws -> DefectReportDetail {
         DefectReportDetail(
             id: roomId,
+            analysisID: 1,
             imageURL: nil,
             type: .crack,
             severity: .medium,
@@ -62,8 +63,8 @@ final class MockDefectRepository: DefectRepositoryProtocol {
             totalCost: 100000,
             totalArea: 0.5,
             defects: [
-                DefectReportDetail(id: 1, imageURL: nil, type: .crack, severity: .high, description: "벽면 균열", repairCost: 60000, defectArea: 0.3, location: "거실 벽", discoveredDate: nil, memo: nil, x: nil, y: nil, z: nil, region3d: []),
-                DefectReportDetail(id: 2, imageURL: nil, type: .stain, severity: .medium, description: "천장 얼룩", repairCost: 40000, defectArea: 0.2, location: "천장", discoveredDate: nil, memo: nil, x: nil, y: nil, z: nil, region3d: [])
+                DefectReportDetail(id: 1, analysisID: 1, imageURL: nil, type: .crack, severity: .high, description: "벽면 균열", repairCost: 60000, defectArea: 0.3, location: "거실 벽", discoveredDate: nil, memo: nil, x: nil, y: nil, z: nil, region3d: []),
+                DefectReportDetail(id: 2, analysisID: 1, imageURL: nil, type: .stain, severity: .medium, description: "천장 얼룩", repairCost: 40000, defectArea: 0.2, location: "천장", discoveredDate: nil, memo: nil, x: nil, y: nil, z: nil, region3d: [])
             ],
             plyURL: nil,
             createdAt: Date()

--- a/RoomLog/RoomLog/Features/Defect/Domain/Models/DefectReportDetail.swift
+++ b/RoomLog/RoomLog/Features/Defect/Domain/Models/DefectReportDetail.swift
@@ -8,6 +8,7 @@ import Foundation
 
 struct DefectReportDetail: Hashable {
     let id: Int
+    let analysisID: Int
     let imageURL: String?
     let type: DefectType
     let severity: Severity

--- a/RoomLog/RoomLog/Features/Estimate/Presentation/ViewModels/RepairShopListViewModel.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Presentation/ViewModels/RepairShopListViewModel.swift
@@ -17,7 +17,6 @@ final class RepairShopListViewModel {
     private(set) var shops: [RepairShop] = []
     private(set) var isLoading = false
     private(set) var isSubmitting = false
-    private(set) var analysisId: Int?
     var selectedShop: RepairShop?
     var viewMode: ViewMode = .list
     var errorMessage: String?
@@ -66,8 +65,7 @@ final class RepairShopListViewModel {
         do {
             let result = try await provider.makeGetRepairShopsByRoomUseCase().execute(roomId: roomId)
             shops = result.shops
-            analysisId = result.analysisId
-            print("[Estimate] fetchShops OK — count=\(result.shops.count), analysisId=\(String(describing: result.analysisId))")
+            print("[Estimate] fetchShops OK — count=\(result.shops.count)")
         } catch {
             errorMessage = error.localizedDescription
             print("[Estimate] fetchShops FAIL — \(error)")
@@ -80,17 +78,14 @@ final class RepairShopListViewModel {
 
     func requestInquiry() async {
         guard let shop = selectedShop else { return }
-        guard let analysisId else {
-            errorMessage = "분석 정보가 없어 문의 미리보기를 생성할 수 없습니다."
-            return
-        }
+        let analysisID = defect.analysisID
         isLoadingPreview = true
         defer { isLoadingPreview = false }
         do {
             let message = "\(messageTitle)\n\n\(messageBody)"
             let result = try await provider.makePreviewEstimateUseCase().execute(
                 message: message,
-                analysisId: analysisId,
+                analysisId: analysisID,
                 providerExternalId: shop.externalId
             )
             preview = result
@@ -109,7 +104,7 @@ final class RepairShopListViewModel {
             try await provider.makeCreateEstimateUseCase().execute(
                 message: composedMessage,
                 roomId: roomId,
-                analysisId: analysisId,
+                analysisId: defect.analysisID,
                 defectIds: [defect.id],
                 provider: shop
             )

--- a/RoomLog/RoomLog/Features/Estimate/Presentation/Views/RepairHistoryView.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Presentation/Views/RepairHistoryView.swift
@@ -244,7 +244,7 @@ private struct RepairHistoryCard: View {
                 dateAndShopInfo
             }
             Spacer()
-            statusBadge
+            StatusBadge(estimateStatus: estimate.displayStatus)
         }
         .padding(16)
         .background(.white, in: RoundedRectangle(cornerRadius: 12))
@@ -300,31 +300,6 @@ private struct RepairHistoryCard: View {
                     .foregroundStyle(Color.neutral700)
                     .lineLimit(1)
             }
-        }
-    }
-
-    // MARK: - 상태 뱃지
-
-    private var statusBadge: some View {
-        Text(estimate.displayStatus.label)
-            .font(.system(size: 16, weight: .medium))
-            .foregroundStyle(statusForeground)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background(statusBackground, in: RoundedRectangle(cornerRadius: 16))
-    }
-
-    private var statusForeground: Color {
-        switch estimate.displayStatus {
-        case .inProgress: .white
-        case .completed: Color.mutedBlue
-        }
-    }
-
-    private var statusBackground: Color {
-        switch estimate.displayStatus {
-        case .inProgress: Color.mutedBlue
-        case .completed: Color.blueGray50
         }
     }
 

--- a/RoomLog/RoomLog/Features/Estimate/Presentation/Views/RepairShopListView.swift
+++ b/RoomLog/RoomLog/Features/Estimate/Presentation/Views/RepairShopListView.swift
@@ -381,6 +381,7 @@ private struct ShopMapCard: View {
     let di = DIContainer.configured()
     let mockDefect = DefectReportDetail(
         id: 1,
+        analysisID: 1,
         imageURL: nil,
         type: .scratch,
         severity: .medium,

--- a/RoomLog/RoomLog/Utilities/PreviewMocks/PreviewMocks.swift
+++ b/RoomLog/RoomLog/Utilities/PreviewMocks/PreviewMocks.swift
@@ -85,11 +85,11 @@ enum PreviewSampleData {
     ]
 
     static let defects: [DefectReportDetail] = [
-        DefectReportDetail(id: 1, imageURL: nil, type: .scratch, severity: .high, description: "벽지가 심하게 찢어져 있음", repairCost: 15000, defectArea: 0.24, location: "거실 벽면 북서부", discoveredDate: nil, memo: nil, x: 0.3, y: 0.4, z: nil, region3d: []),
-        DefectReportDetail(id: 2, imageURL: nil, type: .crack, severity: .medium, description: "바닥에 찍힌 자국", repairCost: 15000, defectArea: 0.24, location: "거실 중앙부", discoveredDate: nil, memo: nil, x: 0.5, y: 0.6, z: nil, region3d: []),
-        DefectReportDetail(id: 3, imageURL: nil, type: .peeling, severity: .low, description: "경미한 벽지 손상", repairCost: 15000, defectArea: 0.24, location: "거실 벽면 북서부", discoveredDate: nil, memo: nil, x: 0.7, y: 0.2, z: nil, region3d: []),
-        DefectReportDetail(id: 4, imageURL: nil, type: .stain, severity: .high, description: "큰 면적 벽지 손상", repairCost: 25000, defectArea: 0.35, location: "안방 벽면", discoveredDate: nil, memo: nil, x: nil, y: nil, z: nil, region3d: []),
-        DefectReportDetail(id: 5, imageURL: nil, type: .breakage, severity: .medium, description: "바닥 손상", repairCost: 10000, defectArea: 0.12, location: "주방 바닥", discoveredDate: nil, memo: nil, x: nil, y: nil, z: nil, region3d: []),
+        DefectReportDetail(id: 1, analysisID: 1, imageURL: nil, type: .scratch, severity: .high, description: "벽지가 심하게 찢어져 있음", repairCost: 15000, defectArea: 0.24, location: "거실 벽면 북서부", discoveredDate: nil, memo: nil, x: 0.3, y: 0.4, z: nil, region3d: []),
+        DefectReportDetail(id: 2, analysisID: 1, imageURL: nil, type: .crack, severity: .medium, description: "바닥에 찍힌 자국", repairCost: 15000, defectArea: 0.24, location: "거실 중앙부", discoveredDate: nil, memo: nil, x: 0.5, y: 0.6, z: nil, region3d: []),
+        DefectReportDetail(id: 3, analysisID: 1, imageURL: nil, type: .peeling, severity: .low, description: "경미한 벽지 손상", repairCost: 15000, defectArea: 0.24, location: "거실 벽면 북서부", discoveredDate: nil, memo: nil, x: 0.7, y: 0.2, z: nil, region3d: []),
+        DefectReportDetail(id: 4, analysisID: 1, imageURL: nil, type: .stain, severity: .high, description: "큰 면적 벽지 손상", repairCost: 25000, defectArea: 0.35, location: "안방 벽면", discoveredDate: nil, memo: nil, x: nil, y: nil, z: nil, region3d: []),
+        DefectReportDetail(id: 5, analysisID: 1, imageURL: nil, type: .breakage, severity: .medium, description: "바닥 손상", repairCost: 10000, defectArea: 0.12, location: "주방 바닥", discoveredDate: nil, memo: nil, x: nil, y: nil, z: nil, region3d: []),
     ]
 
     static var defectReport: DefectReport {


### PR DESCRIPTION
## ✨ PR 유형
- [x] <!-- 변경 사항 작성 -->새로운 기능 추가
- [x] 코드 리팩토링

<br>

## 🛠️ 작업 내용
 - GET /analyses?houseId= 내방비교 내역 목록 API 연동                                      
 - ComparisonHistory에 AnalysisStatus 추가 (분석 중/완료/실패 상태 표시)
 - PENDING 상태 카드 탭 비활성화 + 상태 뱃지 표시                                          
 - StatusBadge, InfoChip 공통 컴포넌트 추출 (ComparisonHistoryView, RepairHistoryView 적용)

<br>

## 🔍 관련 이슈
- closed #127 

<br>

## 📸 스크린샷 - UI작업인 경우만 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비교 분석 이력 조회 기능 추가
  * 분석 상태(진행 중/완료/실패) 표시 추가
  * 미완료 분석 항목은 흐린 표시로 구분

* **개선 사항**
  * 상태 뱃지 UI 컴포넌트로 일관된 디자인 적용
  * 정보 칩 컴포넌트로 데이터 표시 최적화
  * 수리 이력 상태 표시 UI 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->