### PR TITLE
[Fix] 3D 하자 태그/영역 표시 위치 오류 및 하자 클릭 시 카메라 이동

### DIFF
--- a/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectView.swift
+++ b/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectView.swift
@@ -140,6 +140,15 @@ struct DefectView: View {
 // MARK: - Section 1: 3D PLY 뷰어 + 마커
 
 private extension DefectView {
+    /// Renders the image / 3D model area for a defect report, showing a 3D scene, loading indicator, or placeholder as appropriate.
+    /// 
+    /// The view shows, in order of preference:
+    /// - a local PLY 3D scene with an overlaid camera-direction bar when a local PLY URL is available,
+    /// - a full-size loading indicator when an image URL exists but the PLY is not yet available,
+    /// - a placeholder otherwise.
+    /// It also initiates a background check/download of the PLY asset when the view appears.
+    /// - Parameter report: The defect report whose image/defect data drive the displayed content.
+    /// - Returns: A view containing the image or 3D scene area, clipped to a rounded rectangle and constrained to a 3:4 aspect ratio.
     @ViewBuilder
     func imageSection(report: DefectReport) -> some View {
         Group {

--- a/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectView.swift
+++ b/RoomLog/RoomLog/Features/Defect/Presentation/View/DefectView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct DefectView: View {
     @Environment(\.di) var di
     @State private var viewModel: DefectViewModel
+    @State private var cameraDirection: CameraDirection?
+    @State private var resetCamera = false
     private let skipAutoLoad: Bool
 
     init(roomId: Int, provider: DefectUseCaseProvider) {
@@ -142,7 +144,19 @@ private extension DefectView {
     func imageSection(report: DefectReport) -> some View {
         Group {
             if let localURL = viewModel.plyLocalURL {
-                PLYSceneView(fileURL: localURL, defects: report.defects)
+                ZStack(alignment: .bottom) {
+                    PLYSceneView(
+                        fileURL: localURL,
+                        defects: report.defects,
+                        cameraDirection: $cameraDirection,
+                        resetCamera: $resetCamera
+                    )
+                    PLYCameraDirectionBar(
+                        direction: $cameraDirection,
+                        resetCamera: $resetCamera
+                    )
+                        .padding(.bottom, 10)
+                }
             } else if report.imageURL != nil {
                 ProgressView("3D 모델 로딩 중...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/RoomLog/RoomLog/Features/Home/Presentation/Components/PLYSceneView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Components/PLYSceneView.swift
@@ -53,6 +53,9 @@ struct PLYSceneView: UIViewRepresentable {
         weak var scnView: SCNView?
         var lastAppliedDirection: CameraDirection?
 
+        /// Handles a tap on the SceneKit view and, if a defect overlay was tapped, animates the camera to that defect's center.
+        /// - Parameters:
+        ///   - gesture: The tap gesture recognizer whose touch location is hit-tested against the SCNView to locate defect nodes.
         @objc func handleTap(_ gesture: UITapGestureRecognizer) {
             guard let scnView = gesture.view as? SCNView else { return }
             let location = gesture.location(in: scnView)
@@ -70,6 +73,9 @@ struct PLYSceneView: UIViewRepresentable {
             }
         }
 
+        /// Finds a defect identifier encoded in a node's name or any of its ancestor nodes.
+        /// - Parameter node: The starting `SCNNode` to inspect; the search moves upward through `parent` links.
+        /// - Returns: The integer parsed from a name matching the pattern `"defect_<id>"`, or `nil` if no matching node is found.
         private func findDefectID(from node: SCNNode) -> Int? {
             var current: SCNNode? = node
             while let n = current {
@@ -82,7 +88,12 @@ struct PLYSceneView: UIViewRepresentable {
             return nil
         }
 
-        // MARK: 하자 마커 탭 → 카메라 이동
+        /// Animates the scene camera to frame and look at the specified defect region.
+        /// 
+        /// If `defect.region3d` is empty or `scnView.pointOfView` is missing, the function returns without changes.
+        /// - Parameters:
+        ///   - defect: The defect whose 3D region will be used to compute the camera target.
+        ///   - scnView: The SceneKit view containing the camera to animate.
 
         func animateCameraToDefect(_ defect: DefectReportDetail, in scnView: SCNView) {
             let points = defect.region3d
@@ -105,6 +116,12 @@ struct PLYSceneView: UIViewRepresentable {
             SCNTransaction.commit()
         }
 
+        /// Computes a camera offset vector positioned at a fixed distance from the defect region center, oriented along the region's estimated face normal when available or toward the current camera otherwise.
+        /// - Parameters:
+        ///   - points: 3D points defining the defect region; the first three points are used to estimate a face normal.
+        ///   - center: Centroid of the defect region.
+        ///   - cameraNode: Current camera node used to choose the normal direction or as fallback orientation.
+        /// - Returns: An `SCNVector3` whose length is approximately 3.0, pointing from the region center toward the camera-facing side (or directly toward the camera if a reliable normal cannot be computed).
         private func defectCameraOffset(
             for points: [DefectPoint3D],
             center: SCNVector3,
@@ -144,7 +161,11 @@ struct PLYSceneView: UIViewRepresentable {
             return SCNVector3(dx * scale, dy * scale, dz * scale)
         }
 
-        // MARK: 방향 버튼 → 카메라 이동
+        /// Moves the scene's camera to a preset viewpoint for the specified direction, animating the transition.
+        /// - Parameters:
+        ///   - direction: The target `CameraDirection` (front/back/left/right/top/bottom) to move the camera toward.
+        ///   - scnView: The `SCNView` whose scene and `pointOfView` camera will be repositioned. If the scene or camera is missing, the function has no effect.
+        /// - Note: The camera is positioned relative to the scene's root-node bounding box center and the transition is animated (0.6s, ease in/out).
 
         func moveCamera(direction: CameraDirection, in scnView: SCNView) {
             guard let scene = scnView.scene,
@@ -180,7 +201,10 @@ struct PLYSceneView: UIViewRepresentable {
             SCNTransaction.commit()
         }
 
-        // MARK: 초기화 → SceneKit 기본 시점 복원
+        /// Reset the scene camera to a default viewpoint that frames the scene's root node.
+        /// 
+        /// The camera is moved to a position directly above the scene center at a distance equal to 1.5 × the scene's maximum axis size, the camera's orientation is reset (zeroed Euler angles), and the change is animated with a 0.6s ease-in-out transition. If the view has no scene or pointOfView, the call does nothing.
+        /// - Parameter scnView: The `SCNView` whose pointOfView (camera) will be reset.
 
         func resetToDefaultCamera(in scnView: SCNView) {
             guard let scene = scnView.scene,
@@ -209,10 +233,14 @@ struct PLYSceneView: UIViewRepresentable {
         }
     }
 
+    /// Creates a new coordinator to manage SceneKit interactions and runtime state.
+    /// - Returns: A `Coordinator` instance responsible for gesture handling, defect interaction, and camera control.
     func makeCoordinator() -> Coordinator {
         Coordinator()
     }
 
+    /// Creates and configures an `SCNView` for SwiftUI integration, attaches a tap gesture that forwards taps to the coordinator, loads the scene from `fileURL` and applies defect overlays, and wires the coordinator's runtime state.
+    /// - Returns: A configured `SCNView` ready for display and interaction.
     func makeUIView(context: Context) -> SCNView {
         let scnView = SCNView()
         scnView.backgroundColor = .systemBackground
@@ -236,6 +264,11 @@ struct PLYSceneView: UIViewRepresentable {
         return scnView
     }
 
+    /// Updates the provided `SCNView` with the loaded scene and defect overlays, and responds to camera control bindings (move direction or reset).
+    /// - Parameters:
+    ///   - uiView: The `SCNView` to update; the function will load a scene if needed and refresh defect overlay nodes.
+    ///   - context: The SwiftUI `Context` containing the coordinator used to perform camera animations and maintain coordinator state.
+    /// - Note: This method may trigger camera animations via the coordinator and will clear `resetCamera` / `cameraDirection` bindings after applying their effects.
     func updateUIView(_ uiView: SCNView, context: Context) {
         context.coordinator.defects = defects
 
@@ -266,6 +299,10 @@ struct PLYSceneView: UIViewRepresentable {
         }
     }
 
+    /// Create an `SCNScene` from a Model I/O asset at the specified file URL.
+    /// - Parameters:
+    ///   - url: File URL of the 3D model to load.
+    /// - Returns: An `SCNScene` constructed from the model asset, or `nil` if the scene could not be created.
     private func loadScene(from url: URL) -> SCNScene? {
         let asset = MDLAsset(url: url)
         asset.loadTextures()
@@ -280,6 +317,16 @@ struct PLYSceneView: UIViewRepresentable {
         addDefectOverlays(to: scene, defects: defects)
     }
 
+    /// Adds visual overlays for each defect to the given scene.
+    /// 
+    /// Creates a top-level container node named "defectOverlay" and, for every defect that has a non-empty `region3d`,
+    /// adds a child group node named "defect_<id>" containing:
+    /// - a filled polygon region node representing the defect area, and
+    /// - a marker node positioned at the region centroid showing the defect type and area.
+    /// Defects with empty `region3d` are skipped.
+    — Parameters:
+    ///   - scene: The SceneKit scene to which defect overlay nodes will be added.
+    ///   - defects: An array of defect details; each defect's `region3d` provides the polygon vertices and is used to build the overlay.
     private func addDefectOverlays(to scene: SCNScene, defects: [DefectReportDetail]) {
         let container = SCNNode()
         container.name = "defectOverlay"
@@ -317,7 +364,10 @@ struct PLYSceneView: UIViewRepresentable {
         scene.rootNode.addChildNode(container)
     }
 
-    // MARK: - Polygon
+    /// Creates an SCNNode representing a filled polygon defined by the given 3D points, rendered with a translucent blue material.
+    /// - Parameters:
+    ///   - points: Ordered vertices of the polygon in 3D space; must contain at least three points to form a polygon.
+    /// - Returns: An `SCNNode` whose geometry is the filled polygon with a semi-transparent blue material.
 
     private func createPolygonNode(points: [DefectPoint3D]) -> SCNNode {
         let vertices = points.map { SCNVector3($0.x, $0.y, $0.z) }
@@ -354,7 +404,12 @@ struct PLYSceneView: UIViewRepresentable {
         return SCNNode(geometry: geometry)
     }
 
-    // MARK: - Marker
+    /// Creates a marker node with a billboarded image label showing the given title and formatted area at the specified 3D position.
+    /// - Parameters:
+    ///   - position: World-space position where the marker will be placed.
+    ///   - title: Title text displayed on the label.
+    ///   - area: Area in square meters; rendered as a string formatted to two decimal places (e.g. "12.34 m²").
+    /// - Returns: An `SCNNode` positioned at `position` containing a textured plane that faces the camera and displays the title and area.
 
     private func createMarkerNode(at position: SCNVector3, title: String, area: Double) -> SCNNode {
         let node = SCNNode()
@@ -386,7 +441,11 @@ struct PLYSceneView: UIViewRepresentable {
         return node
     }
 
-    // MARK: - Helpers
+    /// Renders a rounded label image combining a title and subtitle for use as a 3D marker texture.
+    /// - Parameters:
+    ///   - title: The primary text displayed prominently at the top of the label.
+    ///   - subtitle: The secondary text displayed below the title with reduced emphasis.
+    /// - Returns: A `UIImage` sized to fit the text that contains a semi-transparent black rounded background with the title (bold, white) and subtitle (semibold, white at reduced alpha) drawn centered vertically with padding.
 
     private func renderLabel(title: String, subtitle: String) -> UIImage {
         let titleFont = UIFont.systemFont(ofSize: 36, weight: .bold)
@@ -425,6 +484,9 @@ struct PLYSceneView: UIViewRepresentable {
         }
     }
 
+    /// Computes the centroid (arithmetic mean) of the given 3D defect points.
+    /// - Parameter points: Array of `DefectPoint3D` whose coordinates will be averaged; must contain at least one element.
+    /// - Returns: An `SCNVector3` representing the average x, y and z coordinates of the input points.
     private func centroid(of points: [DefectPoint3D]) -> SCNVector3 {
         let n = Float(points.count)
         let x = points.reduce(0 as Float) { $0 + $1.x } / n

--- a/RoomLog/RoomLog/Features/Home/Presentation/Components/PLYSceneView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Components/PLYSceneView.swift
@@ -10,9 +10,208 @@ import SceneKit
 import ModelIO
 import SceneKit.ModelIO
 
+// MARK: - Camera Direction
+
+enum CameraDirection: CaseIterable {
+    case front, back, left, right, top, bottom
+
+    var icon: String {
+        switch self {
+        case .front:  return "arrow.up"
+        case .back:   return "arrow.down"
+        case .left:   return "arrow.left"
+        case .right:  return "arrow.right"
+        case .top:    return "arrow.up.circle"
+        case .bottom: return "arrow.down.circle"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .front:  return "앞"
+        case .back:   return "뒤"
+        case .left:   return "좌"
+        case .right:  return "우"
+        case .top:    return "천장"
+        case .bottom: return "바닥"
+        }
+    }
+}
+
+// MARK: - PLYSceneView
+
 struct PLYSceneView: UIViewRepresentable {
     let fileURL: URL
     var defects: [DefectReportDetail] = []
+    var cameraDirection: Binding<CameraDirection?>?
+    var resetCamera: Binding<Bool>?
+
+    // MARK: - Coordinator
+
+    class Coordinator: NSObject {
+        var defects: [DefectReportDetail] = []
+        weak var scnView: SCNView?
+        var lastAppliedDirection: CameraDirection?
+
+        @objc func handleTap(_ gesture: UITapGestureRecognizer) {
+            guard let scnView = gesture.view as? SCNView else { return }
+            let location = gesture.location(in: scnView)
+
+            let hitResults = scnView.hitTest(location, options: [
+                .searchMode: NSNumber(value: SCNHitTestSearchMode.all.rawValue)
+            ])
+
+            for hit in hitResults {
+                if let defectID = findDefectID(from: hit.node),
+                   let defect = defects.first(where: { $0.id == defectID }) {
+                    animateCameraToDefect(defect, in: scnView)
+                    return
+                }
+            }
+        }
+
+        private func findDefectID(from node: SCNNode) -> Int? {
+            var current: SCNNode? = node
+            while let n = current {
+                if let name = n.name, name.hasPrefix("defect_"),
+                   let id = Int(name.dropFirst("defect_".count)) {
+                    return id
+                }
+                current = n.parent
+            }
+            return nil
+        }
+
+        // MARK: 하자 마커 탭 → 카메라 이동
+
+        func animateCameraToDefect(_ defect: DefectReportDetail, in scnView: SCNView) {
+            let points = defect.region3d
+            guard !points.isEmpty, let cameraNode = scnView.pointOfView else { return }
+
+            let count = Float(points.count)
+            let cx = points.reduce(Float(0)) { $0 + $1.x } / count
+            let cy = points.reduce(Float(0)) { $0 + $1.y } / count
+            let cz = points.reduce(Float(0)) { $0 + $1.z } / count
+            let center = SCNVector3(cx, cy, cz)
+
+            let offset = defectCameraOffset(for: points, center: center, cameraNode: cameraNode)
+            let target = SCNVector3(center.x + offset.x, center.y + offset.y, center.z + offset.z)
+
+            SCNTransaction.begin()
+            SCNTransaction.animationDuration = 0.8
+            SCNTransaction.animationTimingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            cameraNode.position = target
+            cameraNode.look(at: center)
+            SCNTransaction.commit()
+        }
+
+        private func defectCameraOffset(
+            for points: [DefectPoint3D],
+            center: SCNVector3,
+            cameraNode: SCNNode
+        ) -> SCNVector3 {
+            let distance: Float = 3.0
+
+            if points.count >= 3 {
+                let v0 = SCNVector3(points[0].x, points[0].y, points[0].z)
+                let v1 = SCNVector3(points[1].x, points[1].y, points[1].z)
+                let v2 = SCNVector3(points[2].x, points[2].y, points[2].z)
+
+                let e1x = v1.x - v0.x, e1y = v1.y - v0.y, e1z = v1.z - v0.z
+                let e2x = v2.x - v0.x, e2y = v2.y - v0.y, e2z = v2.z - v0.z
+                let nx = e1y * e2z - e1z * e2y
+                let ny = e1z * e2x - e1x * e2z
+                let nz = e1x * e2y - e1y * e2x
+                let len = sqrt(nx * nx + ny * ny + nz * nz)
+
+                if len > 1e-4 {
+                    var nnx = nx / len, nny = ny / len, nnz = nz / len
+                    let toCamX = cameraNode.position.x - center.x
+                    let toCamY = cameraNode.position.y - center.y
+                    let toCamZ = cameraNode.position.z - center.z
+                    let dot = nnx * toCamX + nny * toCamY + nnz * toCamZ
+                    if dot < 0 { nnx = -nnx; nny = -nny; nnz = -nnz }
+                    return SCNVector3(nnx * distance, nny * distance, nnz * distance)
+                }
+            }
+
+            let dx = cameraNode.position.x - center.x
+            let dy = cameraNode.position.y - center.y
+            let dz = cameraNode.position.z - center.z
+            let dirLen = sqrt(dx * dx + dy * dy + dz * dz)
+            guard dirLen > 0 else { return SCNVector3(0, 0, distance) }
+            let scale = distance / dirLen
+            return SCNVector3(dx * scale, dy * scale, dz * scale)
+        }
+
+        // MARK: 방향 버튼 → 카메라 이동
+
+        func moveCamera(direction: CameraDirection, in scnView: SCNView) {
+            guard let scene = scnView.scene,
+                  let cameraNode = scnView.pointOfView else { return }
+
+            let (minBound, maxBound) = scene.rootNode.boundingBox
+            let centerX = (minBound.x + maxBound.x) / 2
+            let centerY = (minBound.y + maxBound.y) / 2
+            let centerZ = (minBound.z + maxBound.z) / 2
+            let center = SCNVector3(centerX, centerY, centerZ)
+
+            let sizeX = maxBound.x - minBound.x
+            let sizeY = maxBound.y - minBound.y
+            let sizeZ = maxBound.z - minBound.z
+            let maxSize = max(sizeX, max(sizeY, sizeZ))
+            let dist = maxSize * 1.2
+
+            let position: SCNVector3
+            switch direction {
+            case .front:  position = SCNVector3(centerX, centerY, centerZ + dist)
+            case .back:   position = SCNVector3(centerX, centerY, centerZ - dist)
+            case .left:   position = SCNVector3(centerX - dist, centerY, centerZ)
+            case .right:  position = SCNVector3(centerX + dist, centerY, centerZ)
+            case .top:    position = SCNVector3(centerX, centerY + dist, centerZ)
+            case .bottom: position = SCNVector3(centerX, centerY - dist, centerZ)
+            }
+
+            SCNTransaction.begin()
+            SCNTransaction.animationDuration = 0.6
+            SCNTransaction.animationTimingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            cameraNode.position = position
+            cameraNode.look(at: center)
+            SCNTransaction.commit()
+        }
+
+        // MARK: 초기화 → SceneKit 기본 시점 복원
+
+        func resetToDefaultCamera(in scnView: SCNView) {
+            guard let scene = scnView.scene,
+                  let cameraNode = scnView.pointOfView else { return }
+
+            let (minBound, maxBound) = scene.rootNode.boundingBox
+            let centerX = (minBound.x + maxBound.x) / 2
+            let centerY = (minBound.y + maxBound.y) / 2
+            let centerZ = (minBound.z + maxBound.z) / 2
+            let center = SCNVector3(centerX, centerY, centerZ)
+
+            let sizeX = maxBound.x - minBound.x
+            let sizeY = maxBound.y - minBound.y
+            let sizeZ = maxBound.z - minBound.z
+            let maxSize = max(sizeX, max(sizeY, sizeZ))
+            let dist = maxSize * 1.5
+
+            let position = SCNVector3(centerX, centerY, centerZ + dist)
+
+            SCNTransaction.begin()
+            SCNTransaction.animationDuration = 0.6
+            SCNTransaction.animationTimingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            cameraNode.position = position
+            cameraNode.eulerAngles = SCNVector3(0, 0, 0)
+            SCNTransaction.commit()
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
 
     func makeUIView(context: Context) -> SCNView {
         let scnView = SCNView()
@@ -20,20 +219,50 @@ struct PLYSceneView: UIViewRepresentable {
         scnView.allowsCameraControl = true
         scnView.autoenablesDefaultLighting = true
 
+        let tap = UITapGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleTap(_:))
+        )
+        scnView.addGestureRecognizer(tap)
+
         if let scene = loadScene(from: fileURL) {
             updateDefectOverlays(in: scene, defects: defects)
             scnView.scene = scene
+
         }
+        context.coordinator.defects = defects
+        context.coordinator.scnView = scnView
 
         return scnView
     }
 
     func updateUIView(_ uiView: SCNView, context: Context) {
+        context.coordinator.defects = defects
+
         if uiView.scene == nil, let scene = loadScene(from: fileURL) {
             updateDefectOverlays(in: scene, defects: defects)
             uiView.scene = scene
         } else if let scene = uiView.scene {
             updateDefectOverlays(in: scene, defects: defects)
+        }
+
+        // 카메라 초기화 처리
+        if let binding = resetCamera, binding.wrappedValue {
+            context.coordinator.resetToDefaultCamera(in: uiView)
+            context.coordinator.lastAppliedDirection = nil
+            DispatchQueue.main.async { binding.wrappedValue = false }
+        }
+
+        // 카메라 방향 버튼 처리
+        if let binding = cameraDirection,
+           let direction = binding.wrappedValue,
+           direction != context.coordinator.lastAppliedDirection {
+            context.coordinator.lastAppliedDirection = direction
+            context.coordinator.moveCamera(direction: direction, in: uiView)
+            DispatchQueue.main.async { binding.wrappedValue = nil }
+        }
+        if cameraDirection?.wrappedValue == nil {
+            context.coordinator.lastAppliedDirection = nil
         }
     }
 
@@ -58,16 +287,21 @@ struct PLYSceneView: UIViewRepresentable {
         for defect in defects {
             guard !defect.region3d.isEmpty else { continue }
             let points = defect.region3d
+
             #if DEBUG
             print("[PLY] defect \(defect.id): \(points.count) points")
+            for (i, p) in points.enumerated() {
+                print("  [\(i)] x=\(p.x) y=\(p.y) z=\(p.z)")
+            }
             #endif
 
-            // 1. 파란색 영역 — 꼭짓점을 순서대로 이어 polygon
+            let group = SCNNode()
+            group.name = "defect_\(defect.id)"
+
             let regionNode = createPolygonNode(points: points)
             regionNode.renderingOrder = 1
-            container.addChildNode(regionNode)
+            group.addChildNode(regionNode)
 
-            // 2. 마커 — 중심점에 하자 이름 + 면적 표시
             let center = centroid(of: points)
             let markerNode = createMarkerNode(
                 at: center,
@@ -75,25 +309,24 @@ struct PLYSceneView: UIViewRepresentable {
                 area: defect.defectArea
             )
             markerNode.renderingOrder = 10
-            container.addChildNode(markerNode)
+            group.addChildNode(markerNode)
+
+            container.addChildNode(group)
         }
 
         scene.rootNode.addChildNode(container)
     }
 
-    // MARK: - Polygon (순서대로 이은 삼각형 팬)
+    // MARK: - Polygon
 
     private func createPolygonNode(points: [DefectPoint3D]) -> SCNNode {
         let vertices = points.map { SCNVector3($0.x, $0.y, $0.z) }
 
-        // 삼각형 팬: vertex 0 기준
         var indices: [Int32] = []
         for i in 1..<(vertices.count - 1) {
-            // 앞면
             indices.append(0)
             indices.append(Int32(i))
             indices.append(Int32(i + 1))
-            // 뒷면 (양면 렌더링 보장)
             indices.append(0)
             indices.append(Int32(i + 1))
             indices.append(Int32(i))
@@ -111,22 +344,22 @@ struct PLYSceneView: UIViewRepresentable {
         let geometry = SCNGeometry(sources: [vertexSource], elements: [element])
 
         let material = SCNMaterial()
-        material.diffuse.contents = UIColor.systemBlue.withAlphaComponent(0.4)
-        material.emission.contents = UIColor.systemBlue.withAlphaComponent(0.2)
+        material.diffuse.contents = UIColor.systemBlue.withAlphaComponent(0.15)
+        material.emission.contents = UIColor.systemBlue.withAlphaComponent(0.08)
         material.isDoubleSided = true
-        material.writesToDepthBuffer = false  // 포인트 클라우드 위에 항상 보이게
+        material.writesToDepthBuffer = false
+        material.readsFromDepthBuffer = false
         geometry.materials = [material]
 
         return SCNNode(geometry: geometry)
     }
 
-    // MARK: - Marker (흰색 구 + 라벨)
+    // MARK: - Marker
 
     private func createMarkerNode(at position: SCNVector3, title: String, area: Double) -> SCNNode {
         let node = SCNNode()
         node.position = position
 
-        // 라벨 — UIImage 텍스처로 렌더링 (하자 이름 + 면적)
         let areaText = String(format: "%.2f m²", area)
         let labelImage = renderLabel(title: title, subtitle: areaText)
         let aspect = labelImage.size.width / labelImage.size.height
@@ -138,12 +371,12 @@ struct PLYSceneView: UIViewRepresentable {
         planeMat.emission.contents = labelImage
         planeMat.isDoubleSided = true
         planeMat.writesToDepthBuffer = false
+        planeMat.readsFromDepthBuffer = false
         plane.materials = [planeMat]
 
         let labelNode = SCNNode(geometry: plane)
         labelNode.position = SCNVector3(0, 0.5, 0)
 
-        // 빌보드 — 항상 카메라를 향하게
         let billboard = SCNBillboardConstraint()
         billboard.freeAxes = .all
         node.constraints = [billboard]
@@ -155,7 +388,6 @@ struct PLYSceneView: UIViewRepresentable {
 
     // MARK: - Helpers
 
-    /// 하자 이름 + 면적을 둥근 배경의 UIImage로 렌더링
     private func renderLabel(title: String, subtitle: String) -> UIImage {
         let titleFont = UIFont.systemFont(ofSize: 36, weight: .bold)
         let subtitleFont = UIFont.systemFont(ofSize: 28, weight: .semibold)
@@ -199,5 +431,56 @@ struct PLYSceneView: UIViewRepresentable {
         let y = points.reduce(0 as Float) { $0 + $1.y } / n
         let z = points.reduce(0 as Float) { $0 + $1.z } / n
         return SCNVector3(x, y, z)
+    }
+}
+
+// MARK: - Camera Direction Bar
+
+struct PLYCameraDirectionBar: View {
+    @Binding var direction: CameraDirection?
+    @Binding var resetCamera: Bool
+    @State private var selected: CameraDirection?
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(CameraDirection.allCases, id: \.label) { dir in
+                Button {
+                    selected = dir
+                    direction = dir
+                } label: {
+                    VStack(spacing: 2) {
+                        Image(systemName: dir.icon)
+                            .font(.system(size: 14, weight: .semibold))
+                        Text(dir.label)
+                            .font(.system(size: 10, weight: .medium))
+                    }
+                    .foregroundStyle(selected == dir ? .black : .white)
+                    .frame(width: 44, height: 44)
+                    .background(
+                        selected == dir
+                            ? AnyShapeStyle(Color.white)
+                            : AnyShapeStyle(.clear),
+                        in: RoundedRectangle(cornerRadius: 8)
+                    )
+                }
+            }
+
+            Divider()
+                .frame(height: 28)
+                .background(.white.opacity(0.3))
+
+            Button {
+                selected = nil
+                resetCamera = true
+            } label: {
+                Image(systemName: "arrow.counterclockwise")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 44, height: 44)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(.black.opacity(0.55), in: RoundedRectangle(cornerRadius: 12))
     }
 }

--- a/RoomLog/RoomLog/Features/Home/Presentation/Components/PLYSceneView.swift
+++ b/RoomLog/RoomLog/Features/Home/Presentation/Components/PLYSceneView.swift
@@ -324,7 +324,7 @@ struct PLYSceneView: UIViewRepresentable {
     /// - a filled polygon region node representing the defect area, and
     /// - a marker node positioned at the region centroid showing the defect type and area.
     /// Defects with empty `region3d` are skipped.
-    — Parameters:
+    /// - Parameters:
     ///   - scene: The SceneKit scene to which defect overlay nodes will be added.
     ///   - defects: An array of defect details; each defect's `region3d` provides the polygon vertices and is used to build the overlay.
     private func addDefectOverlays(to scene: SCNScene, defects: [DefectReportDetail]) {


### PR DESCRIPTION
## ✨ PR 유형
- [x] <!-- 변경 사항 작성 -->새로운 기능 추가 
- [x] 버그수정

<br>

## 🛠️ 작업 내용
- <!-- 작업 내용 작성 -->PLY 3D 뷰어에 카메라 방향 조작 바 추가 (앞/뒤/좌/우/천장/바닥)              
- 선택된 방향 버튼 하이라이트 처리 (흰색 배경 + 검정 아이콘)                  
- 카메라 초기화 버튼 추가 (bounding box 기반 기본 시점 복원)                  
- 하자 마커 탭 시 해당 하자로 카메라 이동                          

<br>

## 🔍 관련 이슈
- closed #133 

<br>

## 📸 스크린샷 - UI작업인 경우만 추가

https://github.com/user-attachments/assets/f04ca42d-a305-4e73-8d12-811c61d82ae4




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 3D 뷰에서 카메라 방향 선택(앞/뒤/좌/우/위/아래) 기능 추가
  * 카메라를 기본 위치로 되돌리는 리셋 기능 추가
  * 직관적인 방향 선택 UI 컨트롤 바 추가
  * 결함 탭에서 결함 영역을 자동으로 프레임/룩앳하는 카메라 보정 기능 추가

* **스타일**
  * 3D 오버레이와 마커의 시각적 표현 개선(투명도/렌더링 품질 조정)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->